### PR TITLE
Add minimum required Django requirement to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ setup(
     url='https://github.com/trco/django-bootstrap-modal-forms',
     author='Uros Trstenjak',
     author_email='uros.trstenjak@gmail.com',
+    install_requires=[
+        'django>=1.11',
+    ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Framework :: Django',


### PR DESCRIPTION
This package [isn't compatible](https://stackoverflow.com/questions/57447364/cannot-import-name-loginview) with Django versions lower than 1.11. This PR adds this requirement to `setup.py` so that developers are warned when they try to install it with an incompatible version of Django.