### PR TITLE
add FormData API for file input

### DIFF
--- a/bootstrap_modal_forms/static/js/jquery.bootstrap.modal.forms.js
+++ b/bootstrap_modal_forms/static/js/jquery.bootstrap.modal.forms.js
@@ -35,8 +35,10 @@ https://github.com/trco/django-bootstrap-modal-forms
         $.ajax({
             type: $(modalForm).attr("method"),
             url: $(modalForm).attr("action"),
+            processData: false,
+            contentType: false,
             // Serialize form data
-            data: $(modalForm).serialize(),
+            data: new FormData($(modalForm)[0]),
             success: function (response) {
                 if ($(response).find(errorClass).length > 0) {
                     // Form is not valid, update it with errors

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import find_packages, setup
 
-with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
+with open(os.path.join(os.path.dirname(__file__), 'README.rst'), encoding="utf-8") as readme:
     README = readme.read()
 
 # allow setup.py to be run from any path


### PR DESCRIPTION
I used this library for bootstrap modal, but it's not working in my form.
because my form has `type='file'`. So, JQuery can't serialize my file.