### PR TITLE
Support simple Django forms

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+2.0.0
+=====
+
+- add generic view BSModalFormView
+- renamed BSModalForm to BSModalModelForm
+- add form BSModalForm
+
 1.5.0 (2019-11-23)
 ==================
 
@@ -38,7 +45,7 @@ Changelog
 ==================
 
 - add generic views BSModalCreateView, BSModalUpdateView, BSModalReadView, BSModalDeleteView, BSModalLoginView
-- add form BSModalForm
+- add form BSModalModelForm
 - update README.rst
 
 1.3.1 (2018-08-31)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 =====
 
 - add generic view BSModalFormView
-- renamed BSModalForm to BSModalModelForm
+- rename BSModalForm to BSModalModelForm
 - add form BSModalForm
 
 1.5.0 (2019-11-23)
@@ -45,7 +45,7 @@ Changelog
 ==================
 
 - add generic views BSModalCreateView, BSModalUpdateView, BSModalReadView, BSModalDeleteView, BSModalLoginView
-- add form BSModalModelForm
+- add form BSModalForm
 - update README.rst
 
 1.3.1 (2018-08-31)

--- a/README.rst
+++ b/README.rst
@@ -72,16 +72,16 @@ Usage
 1. Form
 *******
 
-Define ModelForm and inherit built-in form ``BSModalForm``.
+Define BookModelForm and inherit built-in form ``BSModalModelForm``.
 
 .. code-block:: python
 
     forms.py
 
     from .models import Book
-    from bootstrap_modal_forms.forms import BSModalForm
+    from bootstrap_modal_forms.forms import BSModalModelForm
 
-    class BookForm(BSModalForm):
+    class BookModelForm(BSModalModelForm):
         class Meta:
             model = Book
             fields = ['title', 'author', 'price']
@@ -141,13 +141,13 @@ Define a class-based view BookCreateView and inherit from built-in generic view 
     views.py
 
     from django.urls import reverse_lazy
-    from .forms import BookForm
+    from .forms import BookModelForm
     from .models import Book
     from bootstrap_modal_forms.generic import BSModalCreateView
 
     class BookCreateView(BSModalCreateView):
         template_name = 'examples/create_book.html'
-        form_class = BookForm
+        form_class = BookModelForm
         success_message = 'Success: Book was created.'
         success_url = reverse_lazy('index')
 
@@ -254,9 +254,9 @@ BSModalDeleteView
 Forms
 =====
 
-Import forms with ``from bootstrap_modal_forms.forms import BSModalForm``.
+Import forms with ``from bootstrap_modal_forms.forms import BSModalModelForm``.
 
-BSModalForm
+BSModalModelForm
     Inherits PopRequestMixin, CreateUpdateAjaxMixin and Django's forms.ModelForm.
 
 Mixins
@@ -533,10 +533,10 @@ For explanation how all the parts of the code work together see paragraph **Usag
     forms.py
 
     from .models import Book
-    from bootstrap_modal_forms.forms import BSModalForm
+    from bootstrap_modal_forms.forms import BSModalModelForm
 
 
-    class BookForm(BSModalForm):
+    class BookModelForm(BSModalModelForm):
         class Meta:
             model = Book
             exclude = ['timestamp']
@@ -693,7 +693,7 @@ For explanation how all the parts of the code work together see paragraph **Usag
 
     from django.urls import reverse_lazy
     from django.views import generic
-    from .forms import BookForm
+    from .forms import BookModelForm
     from .models import Book
     from bootstrap_modal_forms.generic import (BSModalCreateView,
                                                BSModalUpdateView,
@@ -708,7 +708,7 @@ For explanation how all the parts of the code work together see paragraph **Usag
     # Create
     class BookCreateView(BSModalCreateView):
         template_name = 'examples/create_book.html'
-        form_class = BookForm
+        form_class = BookModelForm
         success_message = 'Success: Book was created.'
         success_url = reverse_lazy('index')
 
@@ -716,7 +716,7 @@ For explanation how all the parts of the code work together see paragraph **Usag
     class BookUpdateView(BSModalUpdateView):
         model = Book
         template_name = 'examples/update_book.html'
-        form_class = BookForm
+        form_class = BookModelForm
         success_message = 'Success: Book was updated.'
         success_url = reverse_lazy('index')
 

--- a/README.rst
+++ b/README.rst
@@ -890,8 +890,8 @@ Your view should inherit from ``BSModalFormView``, a view handling properly form
                 self.filter = f'?type={form.cleaned_data["type"]}'
 
             # call the base form_valid (that will call the get_success_url)
-            resp = super().form_valid(form)
-            return resp
+            response = super().form_valid(form)
+            return response
 
         def get_success_url(self):
             return reverse_lazy('index') + self.filter

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ How it works?
     <script type="text/javascript">
     $(document).ready(function() {
 
-        $(".create-book").modalForm({
+        $("#create-book").modalForm({
             formURL: "{% url 'create_book' %}"
         });
 
@@ -172,7 +172,7 @@ Define URL for the view in #3.
 Define the Bootstrap modal window and html element triggering modal opening.
 
 - Same modal window can be used for multiple ``modalForms`` in single template (see #6).
-- Trigger element (in this example button with ``create-book`` class) is used for instantiation of ``modalForm`` in #6.
+- Trigger element (in this example button with ``create-book`` id) is used for instantiation of ``modalForm`` in #6.
 - Any element can be trigger element as long as ``modalForm`` is bound to it.
 - Click event on trigger element loads form's html from #2 within ``<div class="modal-content"></div>`` and sets action attribute of the form to ``formURL`` set in #6.
 
@@ -780,7 +780,8 @@ For explanation how all the parts of the code work together see paragraph **Usag
     <script type="text/javascript">
       $(function () {
 
-        // Create buttons with the bs-modal class, uses the <div> with id="modal" (default)
+        // Update, Read and Delete book buttons (with the bs-modal class)
+        // uses the <div> with id="modal" (default)
         // The formURL is retrieved from the data of the element
         $(".bs-modal").each(function () {
           $(this).modalForm({formURL: $(this).data('form-url')});

--- a/README.rst
+++ b/README.rst
@@ -189,7 +189,7 @@ Define the Bootstrap modal window and html element triggering modal opening.
     </div>
 
     <!-- Create book button -->
-    <button class="create-book btn btn-primary" type="button" name="button">Create Book</button>
+    <button id="create-book" class="btn btn-primary" type="button" name="button">Create book</button>
 
 6. modalForm
 ************
@@ -206,7 +206,7 @@ Add script to the template from #5 and bind the ``modalForm`` to the trigger ele
     <script type="text/javascript">
     $(document).ready(function() {
 
-        $(".create-book").modalForm({
+        $("#create-book").modalForm({
             formURL: "{% url 'create_book' %}"
         });
 
@@ -758,20 +758,20 @@ For explanation how all the parts of the code work together see paragraph **Usag
     </div>
 
     <!-- Create book button -->
-    <button class="create-book btn btn-primary" type="button" name="button">Create book</button>
+    <button id="create-book" class="btn btn-primary" type="button" name="button">Create book</button>
 
     {% for book in books %}
         <div class="text-center">
           <!-- Read book buttons -->
-          <button type="button" class="read-book btn btn-sm btn-primary" data-id="{% url 'read_book' book.pk %}">
+          <button type="button" id="read-book" class="bs-modal btn btn-sm btn-primary" data-form-url="{% url 'read_book' book.pk %}">
             <span class="fa fa-eye"></span>
           </button>
           <!-- Update book buttons -->
-          <button type="button" class="update-book btn btn-sm btn-primary" data-id="{% url 'update_book' book.pk %}">
+          <button type="button" id="update-book" class="bs-modal btn btn-sm btn-primary" data-form-url="{% url 'update_book' book.pk %}">
             <span class="fa fa-pencil"></span>
           </button>
           <!-- Delete book buttons -->
-          <button type="button" class="delete-book btn btn-sm btn-danger" data-id="{% url 'delete_book' book.pk %}">
+          <button type="button" id="delete-book" class="bs-modal btn btn-sm btn-danger" data-form-url="{% url 'delete_book' book.pk %}">
             <span class="fa fa-trash"></span>
           </button>
         </div>
@@ -779,30 +779,153 @@ For explanation how all the parts of the code work together see paragraph **Usag
 
     <script type="text/javascript">
       $(function () {
-        // Create book button
-        $(".create-book").modalForm({formURL: "{% url 'create_book' %}"});
 
-        // Update book buttons
-        $(".update-book").each(function () {
-          $(this).modalForm({formURL: $(this).data('id')});
+        // Create buttons with the bs-modal class, uses the <div> with id="modal" (default)
+        // The formURL is retrieved from the data of the element
+        $(".bs-modal").each(function () {
+          $(this).modalForm({formURL: $(this).data('form-url')});
         });
 
-        // Read book buttons
-        $(".read-book").each(function () {
-          $(this).modalForm({formURL: $(this).data('id')});
-        });
-
-        // Delete book buttons
-        $(".delete-book").each(function () {
-          $(this).modalForm({formURL: $(this).data('id')});
-        });
+        // Create book button, uses the <div> with id="create-modal"
+        $("#create-book").modalForm({formURL: "{% url 'create_book' %}", modalID: "#create-modal"});
 
       });
     </script>
 
 - See the difference between button triggering Create action and buttons triggering Read, Update and Delete actions.
-- Within the for loop in .html file the ``data-id`` attribute of each Update, Read and Delete button should be set to relevant URL with pk argument of the object to be updated, read or deleted.
-- These ``data-id`` URLs should than be retrieved for each button in script and set as ``formURLs`` for ``modalForms`` bound to the buttons.
+- Within the for loop in .html file the ``data-form-url`` attribute of each Update, Read and Delete button should be set to relevant URL with pk argument of the object to be updated, read or deleted.
+- These ``data-form-url`` URLs should than be retrieved for each button in script and set as ``formURLs`` for ``modalForms`` bound to the buttons.
+  As we assign the class ``bs-modal`` to each button triggering a Bootstrap modal view, we can use jquery to do the latter.
+- Notice for the button with id ``create-book`` how we specify a different id for the modal.
+
+Example 4: Basic Django forms in Bootstrap modal
+************************************************
+
+For explanation how all the parts of the code work together see paragraph **Usage**. To test the working solution presented here clone and run **Examples**.
+
+Basic Django forms (without any link to a Django model) can also benefit from Bootstrap modal.
+
+This example will add a form to filter the books by type, allowing also to clear the existing filter.
+
+Define your form by inheriting from ``BSModalForm``.
+
+.. code-block:: python
+
+    forms.py
+
+    from django.contrib.auth.forms import AuthenticationForm
+    from django.contrib.auth.models import User
+
+    class BookFilterForm(BSModalForm):
+        type = forms.ChoiceField(choices=Book.BOOK_TYPES)
+
+        class Meta:
+            fields = ["type", "clear"]
+
+The html template displays the field of your form as well as
+ an extra button `Clear` that sets the `clear` field of the form.
+
+.. code-block:: html
+
+    filter_book.html
+
+    {% load widget_tweaks %}
+
+    <form method="post" action="">
+      {% csrf_token %}
+
+      <div class="modal-header">
+        <h3 class="modal-title">Filter Books</h3>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+
+
+      <div class="modal-body">
+
+        <div class="{% if form.non_field_errors %}invalid{% endif %} mb-2">
+          {% for error in form.non_field_errors %}
+            {{ error }}
+          {% endfor %}
+        </div>
+
+        {% for field in form %}
+          <div class="form-group">
+            <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+            {% render_field field class="form-control" placeholder=field.label %}
+            <div class="{% if field.errors %} invalid{% endif %}">
+              {% for error in field.errors %}
+                <p class="help-block">{{ error }}</p>
+              {% endfor %}
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+
+
+      <div class="modal-footer">
+        <input type="submit" class="btn btn-primary" name="clear" value="Clear"/>
+        <button type="button" class="submit-btn btn btn-primary">Filter</button>
+      </div>
+
+    </form>
+
+Your view should inherit from ``BSModalFormView``, a view handling properly forms inheriting from ``BSModalForm``.
+
+.. code-block:: python
+
+    views.py
+
+    class BookFilterView(BSModalFormView):
+        template_name = 'examples/filter_book.html'
+        form_class = BookFilterForm
+
+        def form_valid(self, form):
+            if "clear" in self.request.POST:
+                # the user has clicked on the 'Clear' button
+                self.filter = ''
+            else:
+                # the user has filtered the list of books
+                self.filter = f'?type={form.cleaned_data["type"]}'
+
+            # call the base form_valid (that will call the get_success_url)
+            resp = super().form_valid(form)
+            return resp
+
+        def get_success_url(self):
+            return reverse_lazy('index') + self.filter
+
+.. code-block:: python
+
+    urls.py
+
+    from django.urls import path
+    from . import views
+
+    app_name = 'accounts'
+    urlpatterns = [
+        path('filter/', views.BookFilterView.as_view(), name='filter_book'),
+    ]
+
+You can finally add to the index.html the extra `Filter` button.
+
+.. code-block:: html
+
+    index.html (adaptation to existing index.html from example 3)
+
+      <!-- replace the previous create-book button with the following button bar -->
+      <div class="col-12 mb-3">
+        <button id="create-book" class="btn btn-primary" type="button" name="button">
+          <span class="fa fa-plus mr-2"></span>Create book
+        </button>
+        <button id="filter-book" class="bs-modal btn btn-primary" type="button" name="button" data-form-url="{% url 'filter_book' %}">
+          <span class="fa fa-filter mr-2"></span>Filter books
+        </button>
+      </div>
+
+- Notice how easily we add a button triggering a new modal view by just adding the button with the proper ``bs-modal`` class and data-form-url field.
+
 
 Contribute
 ==========

--- a/README.rst
+++ b/README.rst
@@ -397,12 +397,12 @@ For explanation how all the parts of the code work together see paragraph **Usag
       </div>
     </div>
 
-    <button class="signup-btn btn btn-primary" type="button" name="button">Sign up</button>
+    <button id="signup-btn" class="btn btn-primary" type="button" name="button">Sign up</button>
 
     <script type="text/javascript">
       $(function () {
         // Sign up button
-        $(".signup-btn").modalForm({formURL: "{% url 'signup' %}"});
+        $("#signup-btn").modalForm({formURL: "{% url 'signup' %}"});
 
       });
     </script>
@@ -513,12 +513,12 @@ You can also set the custom login redirection by:
       </div>
     </div>
 
-    <button class="login-btn btn btn-primary" type="button" name="button">Sign up</button>
+    <button id="login-btn" class="btn btn-primary" type="button" name="button">Sign up</button>
 
     <script type="text/javascript">
       $(function () {
         // Log in button
-        $(".login-btn").modalForm({formURL: "{% url 'login' %}"});
+        $("#login-btn").modalForm({formURL: "{% url 'login' %}"});
 
       });
     </script>

--- a/bootstrap_modal_forms/compatibility.py
+++ b/bootstrap_modal_forms/compatibility.py
@@ -38,8 +38,8 @@ class LoginView(SuccessURLAllowedHostsMixin, FormView):
             redirect_to = self.get_success_url()
             if redirect_to == self.request.path:
                 raise ValueError(
-                    "Redirection loop for authenticated user detected. Check that "
-                    "your LOGIN_REDIRECT_URL doesn't point to a login page."
+                    'Redirection loop for authenticated user detected. Check that '
+                    'your LOGIN_REDIRECT_URL doesn\'t point to a login page.'
                 )
             return HttpResponseRedirect(redirect_to)
         return super().dispatch(request, *args, **kwargs)

--- a/bootstrap_modal_forms/forms.py
+++ b/bootstrap_modal_forms/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from bootstrap_modal_forms.mixins import PopRequestMixin, CreateUpdateAjaxMixin
 
 
-class BSForm(PopRequestMixin, CreateUpdateAjaxMixin, forms.Form):
+class BSForm(PopRequestMixin, forms.Form):
     pass
 
 

--- a/bootstrap_modal_forms/forms.py
+++ b/bootstrap_modal_forms/forms.py
@@ -2,5 +2,9 @@ from django import forms
 from bootstrap_modal_forms.mixins import PopRequestMixin, CreateUpdateAjaxMixin
 
 
+class BSForm(PopRequestMixin, CreateUpdateAjaxMixin, forms.Form):
+    pass
+
+
 class BSModalForm(PopRequestMixin, CreateUpdateAjaxMixin, forms.ModelForm):
     pass

--- a/bootstrap_modal_forms/forms.py
+++ b/bootstrap_modal_forms/forms.py
@@ -2,9 +2,9 @@ from django import forms
 from bootstrap_modal_forms.mixins import PopRequestMixin, CreateUpdateAjaxMixin
 
 
-class BSForm(PopRequestMixin, forms.Form):
+class BSModalForm(PopRequestMixin, forms.Form):
     pass
 
 
-class BSModalForm(PopRequestMixin, CreateUpdateAjaxMixin, forms.ModelForm):
+class BSModalModelForm(PopRequestMixin, CreateUpdateAjaxMixin, forms.ModelForm):
     pass

--- a/bootstrap_modal_forms/generic.py
+++ b/bootstrap_modal_forms/generic.py
@@ -3,12 +3,12 @@ from django.contrib.messages.views import SuccessMessageMixin
 from django.views import generic
 from .mixins import PassRequestMixin, DeleteMessageMixin, LoginAjaxMixin
 
-DJANGO_VERSION = django.get_version().split(".")
+DJANGO_VERSION = django.get_version().split('.')
 DJANGO_MAJOR_VERSION = DJANGO_VERSION[0]
 DJANGO_MINOR_VERSION = DJANGO_VERSION[1]
 
 # Import custom LoginView for Django versions < 1.11
-if DJANGO_MAJOR_VERSION == "1" and "11" not in DJANGO_MINOR_VERSION:
+if DJANGO_MAJOR_VERSION == '1' and '11' not in DJANGO_MINOR_VERSION:
     from .compatibility import LoginView
 else:
     from django.contrib.auth.views import LoginView

--- a/bootstrap_modal_forms/generic.py
+++ b/bootstrap_modal_forms/generic.py
@@ -18,7 +18,7 @@ class BSModalLoginView(LoginAjaxMixin, SuccessMessageMixin, LoginView):
     pass
 
 
-class BSModalView(PassRequestMixin, generic.FormView):
+class BSModalFormView(PassRequestMixin, generic.FormView):
     pass
 
 

--- a/bootstrap_modal_forms/generic.py
+++ b/bootstrap_modal_forms/generic.py
@@ -3,12 +3,12 @@ from django.contrib.messages.views import SuccessMessageMixin
 from django.views import generic
 from .mixins import PassRequestMixin, DeleteMessageMixin, LoginAjaxMixin
 
-DJANGO_VERSION = django.get_version().split('.')
-DJANGO_MAJOR_VERSION = DJANGO_VERSION[0];
-DJANGO_MINOR_VERSION = DJANGO_VERSION[1];
+DJANGO_VERSION = django.get_version().split(".")
+DJANGO_MAJOR_VERSION = DJANGO_VERSION[0]
+DJANGO_MINOR_VERSION = DJANGO_VERSION[1]
 
 # Import custom LoginView for Django versions < 1.11
-if DJANGO_MAJOR_VERSION == '1' and '11' not in DJANGO_MINOR_VERSION:
+if DJANGO_MAJOR_VERSION == "1" and "11" not in DJANGO_MINOR_VERSION:
     from .compatibility import LoginView
 else:
     from django.contrib.auth.views import LoginView
@@ -18,13 +18,15 @@ class BSModalLoginView(LoginAjaxMixin, SuccessMessageMixin, LoginView):
     pass
 
 
-class BSModalCreateView(PassRequestMixin, SuccessMessageMixin,
-                        generic.CreateView):
+class BSModalView(PassRequestMixin, generic.FormView):
     pass
 
 
-class BSModalUpdateView(PassRequestMixin, SuccessMessageMixin,
-                        generic.UpdateView):
+class BSModalCreateView(PassRequestMixin, SuccessMessageMixin, generic.CreateView):
+    pass
+
+
+class BSModalUpdateView(PassRequestMixin, SuccessMessageMixin, generic.UpdateView):
     pass
 
 

--- a/bootstrap_modal_forms/mixins.py
+++ b/bootstrap_modal_forms/mixins.py
@@ -13,7 +13,7 @@ class PassRequestMixin(object):
 
     def get_form_kwargs(self):
         kwargs = super(PassRequestMixin, self).get_form_kwargs()
-        kwargs.update({"request": self.request})
+        kwargs.update({'request': self.request})
         return kwargs
 
 
@@ -28,7 +28,7 @@ class PopRequestMixin(object):
     """
 
     def __init__(self, *args, **kwargs):
-        self.request = kwargs.pop("request", None)
+        self.request = kwargs.pop('request', None)
         super(PopRequestMixin, self).__init__(*args, **kwargs)
 
 

--- a/examples/forms.py
+++ b/examples/forms.py
@@ -3,19 +3,19 @@ from django.contrib.auth.forms import UserCreationForm, AuthenticationForm
 from django.contrib.auth.models import User
 
 from bootstrap_modal_forms.mixins import PopRequestMixin, CreateUpdateAjaxMixin
-from bootstrap_modal_forms.forms import BSModalForm, BSForm
+from bootstrap_modal_forms.forms import BSModalModelForm, BSModalForm
 
 from .models import Book
 
 
-class SimpleForm(BSForm):
+class SimpleModalForm(BSModalForm):
     comment = forms.CharField(label="Enter your comment")
 
     class Meta:
         fields = ["comment"]
 
 
-class BookForm(BSModalForm):
+class BookModelForm(BSModalModelForm):
     publication_date = forms.DateField(
         error_messages={"invalid": "Enter a valid date in YYYY-MM-DD format."}
     )

--- a/examples/forms.py
+++ b/examples/forms.py
@@ -9,29 +9,29 @@ from .models import Book
 
 
 class SimpleModalForm(BSModalForm):
-    comment = forms.CharField(label="Enter your comment")
+    comment = forms.CharField(label='Enter your comment')
 
     class Meta:
-        fields = ["comment"]
+        fields = ['comment']
 
 
 class BookModelForm(BSModalModelForm):
     publication_date = forms.DateField(
-        error_messages={"invalid": "Enter a valid date in YYYY-MM-DD format."}
+        error_messages={'invalid': 'Enter a valid date in YYYY-MM-DD format.'}
     )
 
     class Meta:
         model = Book
-        exclude = ["timestamp"]
+        exclude = ['timestamp']
 
 
 class CustomUserCreationForm(PopRequestMixin, CreateUpdateAjaxMixin, UserCreationForm):
     class Meta:
         model = User
-        fields = ["username", "password1", "password2"]
+        fields = ['username', 'password1', 'password2']
 
 
 class CustomAuthenticationForm(AuthenticationForm):
     class Meta:
         model = User
-        fields = ["username", "password"]
+        fields = ['username', 'password']

--- a/examples/forms.py
+++ b/examples/forms.py
@@ -2,9 +2,8 @@ from django import forms
 from django.contrib.auth.forms import UserCreationForm, AuthenticationForm
 from django.contrib.auth.models import User
 
-from bootstrap_modal_forms.mixins import PopRequestMixin, CreateUpdateAjaxMixin
 from bootstrap_modal_forms.forms import BSModalModelForm, BSModalForm
-
+from bootstrap_modal_forms.mixins import PopRequestMixin, CreateUpdateAjaxMixin
 from .models import Book
 
 
@@ -13,6 +12,13 @@ class SimpleModalForm(BSModalForm):
 
     class Meta:
         fields = ['comment']
+
+
+class BookFilterForm(BSModalForm):
+    type = forms.ChoiceField(choices=Book.BOOK_TYPES)
+
+    class Meta:
+        fields = ["type", "clear"]
 
 
 class BookModelForm(BSModalModelForm):

--- a/examples/forms.py
+++ b/examples/forms.py
@@ -7,13 +7,6 @@ from bootstrap_modal_forms.mixins import PopRequestMixin, CreateUpdateAjaxMixin
 from .models import Book
 
 
-class SimpleModalForm(BSModalForm):
-    comment = forms.CharField(label='Enter your comment')
-
-    class Meta:
-        fields = ['comment']
-
-
 class BookFilterForm(BSModalForm):
     type = forms.ChoiceField(choices=Book.BOOK_TYPES)
 
@@ -23,21 +16,21 @@ class BookFilterForm(BSModalForm):
 
 class BookModelForm(BSModalModelForm):
     publication_date = forms.DateField(
-        error_messages={'invalid': 'Enter a valid date in YYYY-MM-DD format.'}
+        error_messages={"invalid": "Enter a valid date in YYYY-MM-DD format."}
     )
 
     class Meta:
         model = Book
-        exclude = ['timestamp']
+        exclude = ["timestamp"]
 
 
 class CustomUserCreationForm(PopRequestMixin, CreateUpdateAjaxMixin, UserCreationForm):
     class Meta:
         model = User
-        fields = ['username', 'password1', 'password2']
+        fields = ["username", "password1", "password2"]
 
 
 class CustomAuthenticationForm(AuthenticationForm):
     class Meta:
         model = User
-        fields = ['username', 'password']
+        fields = ["username", "password"]

--- a/examples/forms.py
+++ b/examples/forms.py
@@ -9,7 +9,7 @@ from .models import Book
 
 
 class SimpleForm(BSForm):
-    comment = forms.CharField(label="Enter a comment")
+    comment = forms.CharField(label="Enter your comment")
 
     class Meta:
         fields = ["comment"]

--- a/examples/forms.py
+++ b/examples/forms.py
@@ -3,29 +3,35 @@ from django.contrib.auth.forms import UserCreationForm, AuthenticationForm
 from django.contrib.auth.models import User
 
 from bootstrap_modal_forms.mixins import PopRequestMixin, CreateUpdateAjaxMixin
-from bootstrap_modal_forms.forms import BSModalForm
+from bootstrap_modal_forms.forms import BSModalForm, BSForm
 
 from .models import Book
 
 
+class SimpleForm(BSForm):
+    comment = forms.CharField(label="Enter a comment")
+
+    class Meta:
+        fields = ["comment"]
+
+
 class BookForm(BSModalForm):
     publication_date = forms.DateField(
-        error_messages={'invalid': 'Enter a valid date in YYYY-MM-DD format.'}
+        error_messages={"invalid": "Enter a valid date in YYYY-MM-DD format."}
     )
 
     class Meta:
         model = Book
-        exclude = ['timestamp']
+        exclude = ["timestamp"]
 
 
-class CustomUserCreationForm(PopRequestMixin, CreateUpdateAjaxMixin,
-                             UserCreationForm):
+class CustomUserCreationForm(PopRequestMixin, CreateUpdateAjaxMixin, UserCreationForm):
     class Meta:
         model = User
-        fields = ['username', 'password1', 'password2']
+        fields = ["username", "password1", "password2"]
 
 
 class CustomAuthenticationForm(AuthenticationForm):
     class Meta:
         model = User
-        fields = ['username', 'password']
+        fields = ["username", "password"]

--- a/examples/templates/examples/delete_book.html
+++ b/examples/templates/examples/delete_book.html
@@ -16,7 +16,7 @@
   </div>
 
   <div class="modal-footer">
-    <button type="submit" class="delete-btn btn btn-danger">Delete</button>
+    <button type="submit" id="delete-btn" class="btn btn-danger">Delete</button>
   </div>
 
 </form>

--- a/examples/templates/examples/filter_book.html
+++ b/examples/templates/examples/filter_book.html
@@ -1,0 +1,41 @@
+{% load widget_tweaks %}
+
+<form method="post" action="">
+  {% csrf_token %}
+
+  <div class="modal-header">
+    <h3 class="modal-title">Filter Books</h3>
+    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+
+
+  <div class="modal-body">
+
+    <div class="{% if form.non_field_errors %}invalid{% endif %} mb-2">
+      {% for error in form.non_field_errors %}
+        {{ error }}
+      {% endfor %}
+    </div>
+
+    {% for field in form %}
+      <div class="form-group">
+        <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+        {% render_field field class="form-control" placeholder=field.label %}
+        <div class="{% if field.errors %} invalid{% endif %}">
+          {% for error in field.errors %}
+            <p class="help-block">{{ error }}</p>
+          {% endfor %}
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+
+
+  <div class="modal-footer">
+    <input type="submit" class="btn btn-primary" name="clear" value="Clear"/>
+    <button type="button" class="submit-btn btn btn-primary">Filter</button>
+  </div>
+
+</form>

--- a/examples/templates/examples/simple.html
+++ b/examples/templates/examples/simple.html
@@ -4,7 +4,7 @@
   {% csrf_token %}
 
   <div class="modal-header">
-    <h3 class="modal-title">Enter an important information</h3>
+    <h3 class="modal-title">Comment this application</h3>
     <button type="button" class="close" data-dismiss="modal" aria-label="Close">
       <span aria-hidden="true">&times;</span>
     </button>

--- a/examples/templates/examples/simple.html
+++ b/examples/templates/examples/simple.html
@@ -1,0 +1,38 @@
+{% load widget_tweaks %}
+
+<form method="post" action="">
+  {% csrf_token %}
+
+  <div class="modal-header">
+    <h3 class="modal-title">Enter an important information</h3>
+    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+
+  <div class="modal-body">
+
+    <div class="{% if form.non_field_errors %}invalid{% endif %} mb-2">
+      {% for error in form.non_field_errors %}
+        {{ error }}
+      {% endfor %}
+    </div>
+
+    {% for field in form %}
+      <div class="form-group">
+        <label for="{{ field.id_for_label }}">{{ field.label }}</label>
+        {% render_field field class="form-control" placeholder=field.label %}
+        <div class="{% if field.errors %} invalid{% endif %}">
+          {% for error in field.errors %}
+            <p class="help-block">{{ error }}</p>
+          {% endfor %}
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+
+  <div class="modal-footer">
+    <button type="button" class="submit-btn btn btn-primary">Send</button>
+  </div>
+
+</form>

--- a/examples/templates/index.html
+++ b/examples/templates/index.html
@@ -51,49 +51,54 @@
 
         <div class="row">
           <div class="col-12 mb-3">
-            <button class="create-book btn btn-primary" type="button" name="button">
-              <span class="fa fa-plus mr-2"></span>Create book</button>
-            <button class="filter-book bs-modal btn btn-primary" type="button" name="button" data-form-url="{% url 'filter_book' %}">
-              <span class="fa fa-filter mr-2"></span>Filter books</button>
+            <button id="create-book" class="btn btn-primary" type="button" name="button">
+              <span class="fa fa-plus mr-2"></span>Create book
+            </button>
+            <button id="filter-book" class="bs-modal btn btn-primary" type="button" name="button" data-form-url="{% url 'filter_book' %}">
+              <span class="fa fa-filter mr-2"></span>Filter books
+            </button>
           </div>
           <div class="col-12 mb-3">
             {% if books %}
               <table class="table">
                 <thead>
-                  <tr>
-                    <th class="text-center" scope="col">#</th>
-                    <th class="text-center" scope="col">Title</th>
-                    <th class="text-center" scope="col">Author</th>
-                    <th class="text-center" scope="col">Type</th>
-                    <th class="text-center" scope="col">Publication date</th>
-                    <th class="text-center" scope="col">Pages</th>
-                    <th class="text-center" scope="col">Price (€)</th>
-                    <th class="text-center" scope="col">Read / Update / Delete</th>
-                  </tr>
+                <tr>
+                  <th class="text-center" scope="col">#</th>
+                  <th class="text-center" scope="col">Title</th>
+                  <th class="text-center" scope="col">Author</th>
+                  <th class="text-center" scope="col">Type</th>
+                  <th class="text-center" scope="col">Publication date</th>
+                  <th class="text-center" scope="col">Pages</th>
+                  <th class="text-center" scope="col">Price (€)</th>
+                  <th class="text-center" scope="col">Read / Update / Delete</th>
+                </tr>
                 </thead>
                 <tbody>
-                  {% for book in books %}
-                    <tr>
-                      <th class="text-center" scope="row">{{ forloop.counter }}</th>
-                      <td class="text-center">{{ book.title }}</td>
-                      <td class="text-center">{{ book.author }}</td>
-                      <td class="text-center">{{ book.get_book_type_display }}</td>
-                      <td class="text-center">{{ book.publication_date }}</td>
-                      <td class="text-center">{{ book.pages }}</td>
-                      <td class="text-center">{{ book.price }}</td>
-                      <td class="text-center">
-                        <button type="button" class="read-book bs-modal btn btn-sm btn-primary" data-form-url="{% url 'read_book' book.pk %}">
-                          <span class="fa fa-eye"></span>
-                        </button>
-                        <button type="button" class="update-book bs-modal btn btn-sm btn-primary" data-form-url="{% url 'update_book' book.pk %}">
-                          <span class="fa fa-pencil"></span>
-                        </button>
-                        <button type="button" class="delete-book bs-modal btn btn-sm btn-danger" data-form-url="{% url 'delete_book' book.pk %}">
-                          <span class="fa fa-trash"></span>
-                        </button>
-                      </td>
-                    </tr>
-                  {% endfor %}
+                {% for book in books %}
+                  <tr>
+                    <th class="text-center" scope="row">{{ forloop.counter }}</th>
+                    <td class="text-center">{{ book.title }}</td>
+                    <td class="text-center">{{ book.author }}</td>
+                    <td class="text-center">{{ book.get_book_type_display }}</td>
+                    <td class="text-center">{{ book.publication_date }}</td>
+                    <td class="text-center">{{ book.pages }}</td>
+                    <td class="text-center">{{ book.price }}</td>
+                    <td class="text-center">
+                      <!-- Read book buttons -->
+                      <button type="button" id="read-book" class="bs-modal btn btn-sm btn-primary" data-form-url="{% url 'read_book' book.pk %}">
+                        <span class="fa fa-eye"></span>
+                      </button>
+                      <!-- Update book buttons -->
+                      <button type="button" id="update-book" class="bs-modal btn btn-sm btn-primary" data-form-url="{% url 'update_book' book.pk %}">
+                        <span class="fa fa-pencil"></span>
+                      </button>
+                      <!-- Delete book buttons -->
+                      <button type="button" id="delete-book" class="bs-modal btn btn-sm btn-danger" data-form-url="{% url 'delete_book' book.pk %}">
+                        <span class="fa fa-trash"></span>
+                      </button>
+                    </td>
+                  </tr>
+                {% endfor %}
                 </tbody>
               </table>
             {% else %}
@@ -101,7 +106,6 @@
             {% endif %}
           </div>
         </div>
-
       </div>
     </div>
   </div>
@@ -110,27 +114,27 @@
 
 {% block extrascripts %}
   <script type="text/javascript">
-    $(function () {
-      // Log in & Sign up buttons
-      // The formURL is given explicitly
-      $(".simple-btn").modalForm({formURL: "{% url 'simple' %}"});
-      $(".login-btn").modalForm({formURL: "{% url 'login' %}"});
-      $(".signup-btn").modalForm({formURL: "{% url 'signup' %}"});
+      $(function () {
+          // Log in & Sign up buttons
+          // The formURL is given explicitly
+          $(".simple-btn").modalForm({formURL: "{% url 'simple' %}"});
+          $(".login-btn").modalForm({formURL: "{% url 'login' %}"});
+          $(".signup-btn").modalForm({formURL: "{% url 'signup' %}"});
 
-      // Create buttons with the bs-modal class, uses the <div> with id="modal" (default)
-      // The formURL is retrieved from the data of the element
-      $(".bs-modal").each(function () {
-        $(this).modalForm({formURL: $(this).data('form-url')});
+          // Create book button, uses the <div> with id="create-modal"
+          $("#create-book").modalForm({formURL: "{% url 'create_book' %}", modalID: "#create-modal"});
+
+          // Create buttons with the bs-modal class, uses the <div> with id="modal" (default)
+          // The formURL is retrieved from the data of the element
+          $(".bs-modal").each(function () {
+              $(this).modalForm({formURL: $(this).data('form-url')});
+          });
+
+          // Hide message
+          $(".alert").fadeTo(2000, 500).slideUp(500, function () {
+              $(".alert").slideUp(500);
+          });
+
       });
-
-      // Create book button, uses the <div> with id="create-modal"
-      $(".create-book").modalForm({formURL: "{% url 'create_book' %}", modalID: "#create-modal"});
-
-      // Hide message
-      $(".alert").fadeTo(2000, 500).slideUp(500, function(){
-        $(".alert").slideUp(500);
-      });
-
-    });
   </script>
 {% endblock extrascripts %}

--- a/examples/templates/index.html
+++ b/examples/templates/index.html
@@ -11,7 +11,7 @@
         <h4>
           <strong>1. Simple form</strong>
         </h4>
-        <p>The simples form with a Bootstrap modal.</p>
+        <p>The simplest form with a Bootstrap modal.</p>
         <div class="row">
           <div class="col-12 mb-3">
             <button class="simple-btn btn btn-primary" type="button" name="button">Send comment</button>
@@ -53,6 +53,8 @@
           <div class="col-12 mb-3">
             <button class="create-book btn btn-primary" type="button" name="button">
               <span class="fa fa-plus mr-2"></span>Create book</button>
+            <button class="filter-book bs-modal btn btn-primary" type="button" name="button" data-form-url="{% url 'filter_book' %}">
+              <span class="fa fa-filter mr-2"></span>Filter books</button>
           </div>
           <div class="col-12 mb-3">
             {% if books %}

--- a/examples/templates/index.html
+++ b/examples/templates/index.html
@@ -80,16 +80,15 @@
                       <td class="text-center">{{ book.pages }}</td>
                       <td class="text-center">{{ book.price }}</td>
                       <td class="text-center">
-                        <button type="button" class="read-book btn btn-sm btn-primary" data-id="{% url 'read_book' book.pk %}">
+                        <button type="button" class="read-book bs-modal btn btn-sm btn-primary" data-form-url="{% url 'read_book' book.pk %}">
                           <span class="fa fa-eye"></span>
                         </button>
-                        <button type="button" class="update-book btn btn-sm btn-primary" data-id="{% url 'update_book' book.pk %}">
+                        <button type="button" class="update-book bs-modal btn btn-sm btn-primary" data-form-url="{% url 'update_book' book.pk %}">
                           <span class="fa fa-pencil"></span>
                         </button>
-                        <button type="button" class="delete-book btn btn-sm btn-danger" data-id="{% url 'delete_book' book.pk %}">
+                        <button type="button" class="delete-book bs-modal btn btn-sm btn-danger" data-form-url="{% url 'delete_book' book.pk %}">
                           <span class="fa fa-trash"></span>
                         </button>
-                        <!--<button type="button" class="delete-book btn btn-sm btn-danger" data-toggle="modal" data-target="#modal" data-id="{% url 'delete_book' book.pk %}"> <span class="fa fa-trash" aria-label="Delete"></span> </button>-->
                       </td>
                     </tr>
                   {% endfor %}
@@ -111,27 +110,19 @@
   <script type="text/javascript">
     $(function () {
       // Log in & Sign up buttons
+      // The formURL is given explicitly
       $(".simple-btn").modalForm({formURL: "{% url 'simple' %}"});
       $(".login-btn").modalForm({formURL: "{% url 'login' %}"});
       $(".signup-btn").modalForm({formURL: "{% url 'signup' %}"});
 
-      // Create book button
+      // Create buttons with the bs-modal class, uses the <div> with id="modal" (default)
+      // The formURL is retrieved from the data of the element
+      $(".bs-modal").each(function () {
+        $(this).modalForm({formURL: $(this).data('form-url')});
+      });
+
+      // Create book button, uses the <div> with id="create-modal"
       $(".create-book").modalForm({formURL: "{% url 'create_book' %}", modalID: "#create-modal"});
-
-      // Update book buttons
-      $(".update-book").each(function () {
-        $(this).modalForm({formURL: $(this).data('id')});
-      });
-
-      // Read book buttons
-      $(".read-book").each(function () {
-        $(this).modalForm({formURL: $(this).data('id')});
-      });
-
-      // Delete book buttons
-      $(".delete-book").each(function () {
-        $(this).modalForm({formURL: $(this).data('id')});
-      })
 
       // Hide message
       $(".alert").fadeTo(2000, 500).slideUp(500, function(){

--- a/examples/templates/index.html
+++ b/examples/templates/index.html
@@ -14,7 +14,7 @@
         <p>Sign up via Bootstrap modal.</p>
         <div class="row">
           <div class="col-12 mb-3">
-            <button class="signup-btn btn btn-primary" type="button" name="button">Sign up</button>
+            <button id="signup-btn" class="btn btn-primary" type="button" name="button">Sign up</button>
           </div>
         </div>
         <h4>
@@ -28,9 +28,9 @@
                 Your are logged in as
                 <strong>{{ user }}</strong>.
               </span>
-              <a href="{% url 'logout' %}" class="logout-btn btn btn-danger" role="button">Log out</a>
+              <a href="{% url 'logout' %}" id="logout-btn" class="btn btn-danger" role="button">Log out</a>
             {% else %}
-              <button class="login-btn btn btn-primary" type="button" name="button">Log in</button>
+              <button id="login-btn" class="btn btn-primary" type="button" name="button">Log in</button>
             {% endif %}
           </div>
 
@@ -108,8 +108,8 @@
       $(function () {
           // Log in & Sign up buttons
           // The formURL is given explicitly
-          $(".login-btn").modalForm({formURL: "{% url 'login' %}"});
-          $(".signup-btn").modalForm({formURL: "{% url 'signup' %}"});
+          $("#login-btn").modalForm({formURL: "{% url 'login' %}"});
+          $("#signup-btn").modalForm({formURL: "{% url 'signup' %}"});
 
           // Create book button, uses the <div> with id="create-modal"
           $("#create-book").modalForm({formURL: "{% url 'create_book' %}", modalID: "#create-modal"});

--- a/examples/templates/index.html
+++ b/examples/templates/index.html
@@ -114,7 +114,8 @@
           // Create book button, uses the <div> with id="create-modal"
           $("#create-book").modalForm({formURL: "{% url 'create_book' %}", modalID: "#create-modal"});
 
-          // Create buttons with the bs-modal class, uses the <div> with id="modal" (default)
+          // Update, Read and Delete book buttons (with the bs-modal class)
+          // uses the <div> with id="modal" (default)
           // The formURL is retrieved from the data of the element
           $(".bs-modal").each(function () {
               $(this).modalForm({formURL: $(this).data('form-url')});

--- a/examples/templates/index.html
+++ b/examples/templates/index.html
@@ -9,7 +9,16 @@
       <div class="col">
         <p class="text-primary">A jQuery plugin for creating AJAX driven Django forms in Bootstrap modal.</p>
         <h4>
-          <strong>1. Signup form</strong>
+          <strong>1. Simple form</strong>
+        </h4>
+        <p>The simples form with a Bootstrap modal.</p>
+        <div class="row">
+          <div class="col-12 mb-3">
+            <button class="simple-btn btn btn-primary" type="button" name="button">Send information</button>
+          </div>
+        </div>
+        <h4>
+          <strong>2. Signup form</strong>
         </h4>
         <p>Sign up via Bootstrap modal.</p>
         <div class="row">
@@ -18,7 +27,7 @@
           </div>
         </div>
         <h4>
-          <strong>2. Login form</strong>
+          <strong>3. Login form</strong>
         </h4>
         <p>Log in via Bootstrap modal. Sign up first.</p>
         <div class="row">
@@ -36,7 +45,7 @@
 
         </div>
         <h4>
-          <strong>3. CRUD actions</strong>
+          <strong>4. CRUD actions</strong>
         </h4>
         <p>Create, Read, Update and Delete books in Bootstrap modal.</p>
 
@@ -102,6 +111,7 @@
   <script type="text/javascript">
     $(function () {
       // Log in & Sign up buttons
+      $(".simple-btn").modalForm({formURL: "{% url 'simple' %}"});
       $(".login-btn").modalForm({formURL: "{% url 'login' %}"});
       $(".signup-btn").modalForm({formURL: "{% url 'signup' %}"});
 

--- a/examples/templates/index.html
+++ b/examples/templates/index.html
@@ -14,7 +14,7 @@
         <p>The simples form with a Bootstrap modal.</p>
         <div class="row">
           <div class="col-12 mb-3">
-            <button class="simple-btn btn btn-primary" type="button" name="button">Send information</button>
+            <button class="simple-btn btn btn-primary" type="button" name="button">Send comment</button>
           </div>
         </div>
         <h4>

--- a/examples/templates/index.html
+++ b/examples/templates/index.html
@@ -9,16 +9,7 @@
       <div class="col">
         <p class="text-primary">A jQuery plugin for creating AJAX driven Django forms in Bootstrap modal.</p>
         <h4>
-          <strong>1. Simple form</strong>
-        </h4>
-        <p>The simplest form with a Bootstrap modal.</p>
-        <div class="row">
-          <div class="col-12 mb-3">
-            <button class="simple-btn btn btn-primary" type="button" name="button">Send comment</button>
-          </div>
-        </div>
-        <h4>
-          <strong>2. Signup form</strong>
+          <strong>1. Signup form</strong>
         </h4>
         <p>Sign up via Bootstrap modal.</p>
         <div class="row">
@@ -27,7 +18,7 @@
           </div>
         </div>
         <h4>
-          <strong>3. Login form</strong>
+          <strong>2. Login form</strong>
         </h4>
         <p>Log in via Bootstrap modal. Sign up first.</p>
         <div class="row">
@@ -45,7 +36,7 @@
 
         </div>
         <h4>
-          <strong>4. CRUD actions</strong>
+          <strong>3. CRUD actions</strong>
         </h4>
         <p>Create, Read, Update and Delete books in Bootstrap modal.</p>
 
@@ -117,7 +108,6 @@
       $(function () {
           // Log in & Sign up buttons
           // The formURL is given explicitly
-          $(".simple-btn").modalForm({formURL: "{% url 'simple' %}"});
           $(".login-btn").modalForm({formURL: "{% url 'login' %}"});
           $(".signup-btn").modalForm({formURL: "{% url 'signup' %}"});
 

--- a/examples/urls.py
+++ b/examples/urls.py
@@ -5,6 +5,7 @@ from . import views
 
 urlpatterns = [
     path('', views.Index.as_view(), name='index'),
+    path('simple/', views.SimpleView.as_view(), name='simple'),
     path('create/', views.BookCreateView.as_view(), name='create_book'),
     path('update/<int:pk>', views.BookUpdateView.as_view(), name='update_book'),
     path('read/<int:pk>', views.BookReadView.as_view(), name='read_book'),

--- a/examples/urls.py
+++ b/examples/urls.py
@@ -6,6 +6,7 @@ from . import views
 urlpatterns = [
     path('', views.Index.as_view(), name='index'),
     path('simple/', views.SimpleFormView.as_view(), name='simple'),
+    path('filter/', views.BookFilterView.as_view(), name='filter_book'),
     path('create/', views.BookCreateView.as_view(), name='create_book'),
     path('update/<int:pk>', views.BookUpdateView.as_view(), name='update_book'),
     path('read/<int:pk>', views.BookReadView.as_view(), name='read_book'),

--- a/examples/urls.py
+++ b/examples/urls.py
@@ -5,7 +5,7 @@ from . import views
 
 urlpatterns = [
     path('', views.Index.as_view(), name='index'),
-    path('simple/', views.SimpleView.as_view(), name='simple'),
+    path('simple/', views.SimpleFormView.as_view(), name='simple'),
     path('create/', views.BookCreateView.as_view(), name='create_book'),
     path('update/<int:pk>', views.BookUpdateView.as_view(), name='update_book'),
     path('read/<int:pk>', views.BookReadView.as_view(), name='read_book'),

--- a/examples/urls.py
+++ b/examples/urls.py
@@ -5,7 +5,6 @@ from . import views
 
 urlpatterns = [
     path('', views.Index.as_view(), name='index'),
-    path('simple/', views.SimpleFormView.as_view(), name='simple'),
     path('filter/', views.BookFilterView.as_view(), name='filter_book'),
     path('create/', views.BookCreateView.as_view(), name='create_book'),
     path('update/<int:pk>', views.BookUpdateView.as_view(), name='update_book'),

--- a/examples/views.py
+++ b/examples/views.py
@@ -48,11 +48,11 @@ class BookFilterView(BSModalFormView):
             self.filter = ''
         else:
             # the user has filtered the list of books
-            self.filter = f'?type={form.cleaned_data["type"]}'
+            self.filter = '?type=' + form.cleaned_data["type"]
 
         # call the base form_valid (that will call the get_success_url)
-        resp = super().form_valid(form)
-        return resp
+        response = super().form_valid(form)
+        return response
 
     def get_success_url(self):
         return reverse_lazy('index') + self.filter

--- a/examples/views.py
+++ b/examples/views.py
@@ -11,7 +11,6 @@ from bootstrap_modal_forms.generic import (
     BSModalFormView,
 )
 from .forms import (
-    SimpleModalForm,
     BookModelForm,
     CustomUserCreationForm,
     CustomAuthenticationForm,
@@ -29,13 +28,6 @@ class Index(generic.ListView):
         if 'type' in self.request.GET:
             qs = qs.filter(book_type=int(self.request.GET['type']))
         return qs
-
-
-class SimpleFormView(SuccessMessageMixin, BSModalFormView):
-    template_name = 'examples/simple.html'
-    form_class = SimpleModalForm
-    success_message = 'Success: your comment \'%(comment)s\' was taken into account!'
-    success_url = reverse_lazy('index')
 
 
 class BookFilterView(BSModalFormView):

--- a/examples/views.py
+++ b/examples/views.py
@@ -29,14 +29,14 @@ class SimpleFormView(SuccessMessageMixin, BSModalFormView):
     template_name = 'examples/simple.html'
     form_class = SimpleModalForm
     success_message = 'Success: your comment \'%(comment)s\' was taken into account!'
-    success_url = reverse_lazy("index")
+    success_url = reverse_lazy('index')
 
 
 class BookCreateView(BSModalCreateView):
     template_name = 'examples/create_book.html'
     form_class = BookModelForm
     success_message = 'Success: Book was created.'
-    success_url = reverse_lazy("index")
+    success_url = reverse_lazy('index')
 
 
 class BookUpdateView(BSModalUpdateView):

--- a/examples/views.py
+++ b/examples/views.py
@@ -15,7 +15,7 @@ from .forms import (
     BookModelForm,
     CustomUserCreationForm,
     CustomAuthenticationForm,
-)
+    BookFilterForm)
 from .models import Book
 
 
@@ -24,12 +24,38 @@ class Index(generic.ListView):
     context_object_name = 'books'
     template_name = 'index.html'
 
+    def get_queryset(self):
+        qs = super().get_queryset()
+        if 'type' in self.request.GET:
+            qs = qs.filter(book_type=int(self.request.GET['type']))
+        return qs
+
 
 class SimpleFormView(SuccessMessageMixin, BSModalFormView):
     template_name = 'examples/simple.html'
     form_class = SimpleModalForm
     success_message = 'Success: your comment \'%(comment)s\' was taken into account!'
     success_url = reverse_lazy('index')
+
+
+class BookFilterView(BSModalFormView):
+    template_name = 'examples/filter_book.html'
+    form_class = BookFilterForm
+
+    def form_valid(self, form):
+        if "clear" in self.request.POST:
+            # the user has clicked on the 'Clear' button
+            self.filter = ''
+        else:
+            # the user has filtered the list of books
+            self.filter = f'?type={form.cleaned_data["type"]}'
+
+        # call the base form_valid (that will call the get_success_url)
+        resp = super().form_valid(form)
+        return resp
+
+    def get_success_url(self):
+        return reverse_lazy('index') + self.filter
 
 
 class BookCreateView(BSModalCreateView):

--- a/examples/views.py
+++ b/examples/views.py
@@ -10,7 +10,12 @@ from bootstrap_modal_forms.generic import (
     BSModalDeleteView,
     BSModalFormView,
 )
-from .forms import SimpleModalForm, BookModelForm, CustomUserCreationForm, CustomAuthenticationForm
+from .forms import (
+    SimpleModalForm,
+    BookModelForm,
+    CustomUserCreationForm,
+    CustomAuthenticationForm,
+)
 from .models import Book
 
 

--- a/examples/views.py
+++ b/examples/views.py
@@ -21,53 +21,53 @@ from .models import Book
 
 class Index(generic.ListView):
     model = Book
-    context_object_name = "books"
-    template_name = "index.html"
+    context_object_name = 'books'
+    template_name = 'index.html'
 
 
 class SimpleFormView(SuccessMessageMixin, BSModalFormView):
-    template_name = "examples/simple.html"
+    template_name = 'examples/simple.html'
     form_class = SimpleModalForm
-    success_message = "Success: your comment '%(comment)s' was taken into account!"
+    success_message = 'Success: your comment \'%(comment)s\' was taken into account!'
     success_url = reverse_lazy("index")
 
 
 class BookCreateView(BSModalCreateView):
-    template_name = "examples/create_book.html"
+    template_name = 'examples/create_book.html'
     form_class = BookModelForm
-    success_message = "Success: Book was created."
+    success_message = 'Success: Book was created.'
     success_url = reverse_lazy("index")
 
 
 class BookUpdateView(BSModalUpdateView):
     model = Book
-    template_name = "examples/update_book.html"
+    template_name = 'examples/update_book.html'
     form_class = BookModelForm
-    success_message = "Success: Book was updated."
-    success_url = reverse_lazy("index")
+    success_message = 'Success: Book was updated.'
+    success_url = reverse_lazy('index')
 
 
 class BookReadView(BSModalReadView):
     model = Book
-    template_name = "examples/read_book.html"
+    template_name = 'examples/read_book.html'
 
 
 class BookDeleteView(BSModalDeleteView):
     model = Book
-    template_name = "examples/delete_book.html"
-    success_message = "Success: Book was deleted."
-    success_url = reverse_lazy("index")
+    template_name = 'examples/delete_book.html'
+    success_message = 'Success: Book was deleted.'
+    success_url = reverse_lazy('index')
 
 
 class SignUpView(BSModalCreateView):
     form_class = CustomUserCreationForm
-    template_name = "examples/signup.html"
-    success_message = "Success: Sign up succeeded. You can now Log in."
-    success_url = reverse_lazy("index")
+    template_name = 'examples/signup.html'
+    success_message = 'Success: Sign up succeeded. You can now Log in.'
+    success_url = reverse_lazy('index')
 
 
 class CustomLoginView(BSModalLoginView):
     authentication_form = CustomAuthenticationForm
-    template_name = "examples/login.html"
-    success_message = "Success: You were successfully logged in."
-    success_url = reverse_lazy("index")
+    template_name = 'examples/login.html'
+    success_message = 'Success: You were successfully logged in.'
+    success_url = reverse_lazy('index')

--- a/examples/views.py
+++ b/examples/views.py
@@ -8,9 +8,9 @@ from bootstrap_modal_forms.generic import (
     BSModalUpdateView,
     BSModalReadView,
     BSModalDeleteView,
-    BSModalView,
+    BSModalFormView,
 )
-from .forms import SimpleForm, BookForm, CustomUserCreationForm, CustomAuthenticationForm
+from .forms import SimpleModalForm, BookModelForm, CustomUserCreationForm, CustomAuthenticationForm
 from .models import Book
 
 
@@ -20,16 +20,16 @@ class Index(generic.ListView):
     template_name = "index.html"
 
 
-class SimpleView(SuccessMessageMixin, BSModalView):
+class SimpleFormView(SuccessMessageMixin, BSModalFormView):
     template_name = "examples/simple.html"
-    form_class = SimpleForm
+    form_class = SimpleModalForm
     success_message = "Success: your comment '%(comment)s' was taken into account!"
     success_url = reverse_lazy("index")
 
 
 class BookCreateView(BSModalCreateView):
     template_name = "examples/create_book.html"
-    form_class = BookForm
+    form_class = BookModelForm
     success_message = "Success: Book was created."
     success_url = reverse_lazy("index")
 
@@ -37,7 +37,7 @@ class BookCreateView(BSModalCreateView):
 class BookUpdateView(BSModalUpdateView):
     model = Book
     template_name = "examples/update_book.html"
-    form_class = BookForm
+    form_class = BookModelForm
     success_message = "Success: Book was updated."
     success_url = reverse_lazy("index")
 

--- a/examples/views.py
+++ b/examples/views.py
@@ -1,58 +1,68 @@
+from django.contrib.messages.views import SuccessMessageMixin
 from django.urls import reverse_lazy
 from django.views import generic
 
-from bootstrap_modal_forms.generic import (BSModalLoginView,
-                                           BSModalCreateView,
-                                           BSModalUpdateView,
-                                           BSModalReadView,
-                                           BSModalDeleteView)
-
-from .forms import BookForm, CustomUserCreationForm, CustomAuthenticationForm
+from bootstrap_modal_forms.generic import (
+    BSModalLoginView,
+    BSModalCreateView,
+    BSModalUpdateView,
+    BSModalReadView,
+    BSModalDeleteView,
+    BSModalView,
+)
+from .forms import SimpleForm, BookForm, CustomUserCreationForm, CustomAuthenticationForm
 from .models import Book
 
 
 class Index(generic.ListView):
     model = Book
-    context_object_name = 'books'
-    template_name = 'index.html'
+    context_object_name = "books"
+    template_name = "index.html"
+
+
+class SimpleView(SuccessMessageMixin, BSModalView):
+    template_name = "examples/simple.html"
+    form_class = SimpleForm
+    success_message = "Success: your comment '%(comment)s' was taken into account!"
+    success_url = reverse_lazy("index")
 
 
 class BookCreateView(BSModalCreateView):
-    template_name = 'examples/create_book.html'
+    template_name = "examples/create_book.html"
     form_class = BookForm
-    success_message = 'Success: Book was created.'
-    success_url = reverse_lazy('index')
+    success_message = "Success: Book was created."
+    success_url = reverse_lazy("index")
 
 
 class BookUpdateView(BSModalUpdateView):
     model = Book
-    template_name = 'examples/update_book.html'
+    template_name = "examples/update_book.html"
     form_class = BookForm
-    success_message = 'Success: Book was updated.'
-    success_url = reverse_lazy('index')
+    success_message = "Success: Book was updated."
+    success_url = reverse_lazy("index")
 
 
 class BookReadView(BSModalReadView):
     model = Book
-    template_name = 'examples/read_book.html'
+    template_name = "examples/read_book.html"
 
 
 class BookDeleteView(BSModalDeleteView):
     model = Book
-    template_name = 'examples/delete_book.html'
-    success_message = 'Success: Book was deleted.'
-    success_url = reverse_lazy('index')
+    template_name = "examples/delete_book.html"
+    success_message = "Success: Book was deleted."
+    success_url = reverse_lazy("index")
 
 
 class SignUpView(BSModalCreateView):
     form_class = CustomUserCreationForm
-    template_name = 'examples/signup.html'
-    success_message = 'Success: Sign up succeeded. You can now Log in.'
-    success_url = reverse_lazy('index')
+    template_name = "examples/signup.html"
+    success_message = "Success: Sign up succeeded. You can now Log in."
+    success_url = reverse_lazy("index")
 
 
 class CustomLoginView(BSModalLoginView):
     authentication_form = CustomAuthenticationForm
-    template_name = 'examples/login.html'
-    success_message = 'Success: You were successfully logged in.'
-    success_url = reverse_lazy('index')
+    template_name = "examples/login.html"
+    success_message = "Success: You were successfully logged in."
+    success_url = reverse_lazy("index")

--- a/manage.py
+++ b/manage.py
@@ -8,8 +8,8 @@ if __name__ == '__main__':
         from django.core.management import execute_from_command_line
     except ImportError as exc:
         raise ImportError(
-            "Couldn't import Django. Are you sure it's installed and "
-            "available on your PYTHONPATH environment variable? Did you "
-            "forget to activate a virtual environment?"
+            'Couldn\'t import Django. Are you sure it\'s installed and '
+            'available on your PYTHONPATH environment variable? Did you '
+            'forget to activate a virtual environment?'
         ) from exc
     execute_from_command_line(sys.argv)

--- a/setup/settings.py
+++ b/setup/settings.py
@@ -97,5 +97,5 @@ STATICFILES_FINDERS = [
 STATIC_URL = '/static/'
 
 STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, "static"),
+    os.path.join(BASE_DIR, 'static'),
 ]

--- a/tests/base.py
+++ b/tests/base.py
@@ -38,6 +38,22 @@ class FunctionalTest(StaticLiveServerTestCase):
                 # Wait for 0.5s and retry
                 time.sleep(0.5)
 
+
+    def wait_for_element(self, element_id):
+        start_time = time.time()
+        # Infinite loop
+        while True:
+            try:
+                element = self.browser.find_element_by_id(element_id)
+                return element
+            except (AssertionError, WebDriverException) as e:
+                # Return exception if more than 10s pass
+                if time.time() - start_time > MAX_WAIT:
+                    raise e
+                # Wait for 0.5s and retry
+                time.sleep(0.5)
+
+
     def wait_for_modal(self, modalID):
         start_time = time.time()
         # Infinite loop

--- a/tests/base.py
+++ b/tests/base.py
@@ -10,7 +10,7 @@ class FunctionalTest(StaticLiveServerTestCase):
 
     # Basic setUp & tearDown
     def setUp(self):
-        self.browser = webdriver.Firefox()
+        self.browser = webdriver.Chrome()
 
     def tearDown(self):
         self.browser.quit()

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,7 +1,8 @@
-import time
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from selenium import webdriver
-from selenium.common.exceptions import WebDriverException
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions
+from selenium.webdriver.support.wait import WebDriverWait
 
 MAX_WAIT = 10
 
@@ -10,80 +11,32 @@ class FunctionalTest(StaticLiveServerTestCase):
 
     # Basic setUp & tearDown
     def setUp(self):
-        self.browser = webdriver.Chrome()
+        self._initialise_firefox()
+
+    def _initialise_firefox(self):
+        self.browser = webdriver.Firefox()
+
+    def _initialise_chrome(self):
+        chrome_options = webdriver.ChromeOptions()
+        # disable warning when opening Chrome without admin rights on extension
+        chrome_options.add_experimental_option('useAutomationExtension', False)
+        self.browser = webdriver.Chrome(chrome_options=chrome_options)
 
     def tearDown(self):
         self.browser.quit()
 
-    def wait_for_text_in_body(self, *args, not_in=None):
-        start_time = time.time()
-        # Infinite loop
-        while True:
-            try:
-                body = self.browser.find_element_by_tag_name('body')
-                body_text = body.text
-                # Check that text is in body
-                if not not_in:
-                    for arg in args:
-                        self.assertIn(arg, body_text)
-                # Check there is no text in body
-                else:
-                    for arg in args:
-                        self.assertNotIn(arg, body_text)
-                return
-            except (AssertionError, WebDriverException) as e:
-                # Return exception if more than 10s pass
-                if time.time() - start_time > MAX_WAIT:
-                    raise e
-                # Wait for 0.5s and retry
-                time.sleep(0.5)
-
-
-    def wait_for_element(self, element_id):
-        start_time = time.time()
-        # Infinite loop
-        while True:
-            try:
-                element = self.browser.find_element_by_id(element_id)
-                return element
-            except (AssertionError, WebDriverException) as e:
-                # Return exception if more than 10s pass
-                if time.time() - start_time > MAX_WAIT:
-                    raise e
-                # Wait for 0.5s and retry
-                time.sleep(0.5)
-
-
-    def wait_for_modal(self, modalID):
-        start_time = time.time()
-        # Infinite loop
-        while True:
-            try:
-                modal = self.browser.find_element_by_id(modalID)
-                return modal
-            except (AssertionError, WebDriverException) as e:
-                # Return exception if more than 10s pass
-                if time.time() - start_time > MAX_WAIT:
-                    raise e
-                # Wait for 0.5s and retry
-                time.sleep(0.5)
+    def wait_for(self, class_name=None, element_id=None, tag=None, xpath=None):
+        return WebDriverWait(self.browser, 20).until(
+            expected_conditions.element_to_be_clickable
+            ((By.ID, element_id) if element_id else
+             (By.CLASS_NAME, class_name) if class_name else
+             (By.TAG_NAME, tag) if tag else
+             (By.XPATH, xpath))
+        )
 
     def wait_for_table_rows(self):
-        start_time = time.time()
-        # Infinite loop
-        while True:
-            try:
-                table = self.browser.find_element_by_tag_name('table')
-                tbody = table.find_element_by_tag_name('tbody')
-                # Slice removes tr in thead
-                trs = tbody.find_elements_by_tag_name('tr')
-                return trs
-            except (AssertionError, WebDriverException) as e:
-                # Return exception if more than 10s pass
-                if time.time() - start_time > MAX_WAIT:
-                    raise e
-                # Wait for 0.5s and retry
-                time.sleep(0.5)
+        tbody = self.wait_for(xpath="//table/tbody")
+        return tbody.find_elements_by_tag_name('tr')
 
     def check_table_row(self, table_row, cells_count, cells_values):
         cells = table_row.find_elements_by_tag_name('td')

--- a/tests/tests_functional.py
+++ b/tests/tests_functional.py
@@ -5,105 +5,129 @@ from .base import FunctionalTest
 from examples.models import Book
 
 
-class SignUpLoginTest(FunctionalTest):
-
+class SimpleFormTest(FunctionalTest):
     def test_signup_login(self):
         # User visits homepage and checks the content
         self.browser.get(self.live_server_url)
-        self.assertIn('django-bootstrap-modal-forms', self.browser.title)
-        header_text = self.browser.find_element_by_tag_name('h1').text
-        self.assertIn('django-bootstrap-modal-forms', header_text)
+
+        # User clicks the send comment button
+        self.browser.find_element_by_class_name("simple-btn").click()
+
+        # Create book modal opens
+        modal = self.wait_for_modal("modal")
+
+        # User add a comment
+        form = modal.find_element_by_tag_name("form")
+        comment_field = form.find_element_by_id("id_comment")
+        comment_field.clear()
+        comment_field.send_keys("What a great package!")
+
+        update_btn = modal.find_element_by_class_name("submit-btn")
+        update_btn.click()
+
+        # User sees success message after page redirection
+        redirect_url = self.browser.current_url
+        self.assertRegex(redirect_url, "/")
+
+        # Slice removes '\nx' since alert is dismissible and contains 'times' button
+        success_msg = self.browser.find_element_by_class_name("alert").text[:-2]
+        self.assertEqual(success_msg, "Success: your comment 'What a great package!' was taken into account!")
+
+
+class SignUpLoginTest(FunctionalTest):
+    def test_signup_login(self):
+        # User visits homepage and checks the content
+        self.browser.get(self.live_server_url)
+        self.assertIn("django-bootstrap-modal-forms", self.browser.title)
+        header_text = self.browser.find_element_by_tag_name("h1").text
+        self.assertIn("django-bootstrap-modal-forms", header_text)
 
         # User clicks Sign up button
-        self.browser.find_element_by_class_name('signup-btn').click()
+        self.browser.find_element_by_class_name("signup-btn").click()
 
         # Sign up modal opens
         modal = self.wait_for_modal("modal")
 
         # User fills in and submits sign up form with misspelled second password
-        form = modal.find_element_by_tag_name('form')
-        username_field = form.find_element_by_id('id_username')
-        password1_field = form.find_element_by_id('id_password1')
-        password2_field = form.find_element_by_id('id_password2')
-        username_field.send_keys('user')
-        password1_field.send_keys('pass12345')
-        password2_field.send_keys('wrong12345')
-        signup_btn = modal.find_element_by_class_name('submit-btn')
+        form = modal.find_element_by_tag_name("form")
+        username_field = form.find_element_by_id("id_username")
+        password1_field = form.find_element_by_id("id_password1")
+        password2_field = form.find_element_by_id("id_password2")
+        username_field.send_keys("user")
+        password1_field.send_keys("pass12345")
+        password2_field.send_keys("wrong12345")
+        signup_btn = modal.find_element_by_class_name("submit-btn")
         signup_btn.click()
 
         # User sees error in form
-        error = modal.find_element_by_class_name('help-block').text
-        self.assertEqual(error, 'The two password fields didn\'t match.')
+        error = modal.find_element_by_class_name("help-block").text
+        self.assertEqual(error, "The two password fields didn't match.")
 
         # User fills in and submits sign up form correctly
-        form = modal.find_element_by_tag_name('form')
-        password1_field = form.find_element_by_id('id_password1')
-        password2_field = form.find_element_by_id('id_password2')
-        password1_field.send_keys('pass12345')
-        password2_field.send_keys('pass12345')
-        signup_btn = modal.find_element_by_class_name('submit-btn')
+        form = modal.find_element_by_tag_name("form")
+        password1_field = form.find_element_by_id("id_password1")
+        password2_field = form.find_element_by_id("id_password2")
+        password1_field.send_keys("pass12345")
+        password2_field.send_keys("pass12345")
+        signup_btn = modal.find_element_by_class_name("submit-btn")
         signup_btn.click()
 
         # User sees success message after page redirection
         redirect_url = self.browser.current_url
-        self.assertRegex(redirect_url, '/')
+        self.assertRegex(redirect_url, "/")
         # Slice removes '\nx' since alert is dismissible and contains 'times' button
-        success_msg = self.browser.find_element_by_class_name('alert').text[:-2]
-        self.assertEqual(
-            success_msg,
-            'Success: Sign up succeeded. You can now Log in.'
-        )
+        success_msg = self.browser.find_element_by_class_name("alert").text[:-2]
+        self.assertEqual(success_msg, "Success: Sign up succeeded. You can now Log in.")
 
         # User clicks log in button
-        self.browser.find_element_by_class_name('login-btn').click()
+        self.browser.find_element_by_class_name("login-btn").click()
 
         # Log in modal opens
         modal = self.wait_for_modal("modal")
 
         # User fills in and submits log in form with misspelled username
-        form = modal.find_element_by_tag_name('form')
-        username_field = form.find_element_by_id('id_username')
-        password_field = form.find_element_by_id('id_password')
-        username_field.send_keys('wrong')
-        password_field.send_keys('pass12345')
-        login_btn = modal.find_element_by_class_name('submit-btn')
+        form = modal.find_element_by_tag_name("form")
+        username_field = form.find_element_by_id("id_username")
+        password_field = form.find_element_by_id("id_password")
+        username_field.send_keys("wrong")
+        password_field.send_keys("pass12345")
+        login_btn = modal.find_element_by_class_name("submit-btn")
         login_btn.click()
 
         # User sees error in form
-        error = modal.find_element_by_class_name('invalid').text
+        error = modal.find_element_by_class_name("invalid").text
         self.assertEqual(
             error,
-            'Please enter a correct username and password. Note that both fields may be case-sensitive.'
+            "Please enter a correct username and password. Note that both fields may be case-sensitive.",
         )
 
         # User fills in and submits log in form correctly
-        form = modal.find_element_by_tag_name('form')
-        username_field = form.find_element_by_id('id_username')
+        form = modal.find_element_by_tag_name("form")
+        username_field = form.find_element_by_id("id_username")
         username_field.clear()
-        password_field = form.find_element_by_id('id_password')
-        username_field.send_keys('user')
-        password_field.send_keys('pass12345')
-        login_btn = modal.find_element_by_class_name('submit-btn')
+        password_field = form.find_element_by_id("id_password")
+        username_field.send_keys("user")
+        password_field.send_keys("pass12345")
+        login_btn = modal.find_element_by_class_name("submit-btn")
         login_btn.click()
 
         # User sees log out button after page redirection
         redirect_url = self.browser.current_url
-        self.assertRegex(redirect_url, '/')
-        logout_btn_txt = self.browser.find_element_by_class_name('logout-btn').text
-        self.assertEqual(logout_btn_txt, 'Log out')
+        self.assertRegex(redirect_url, "/")
+        logout_btn_txt = self.browser.find_element_by_class_name("logout-btn").text
+        self.assertEqual(logout_btn_txt, "Log out")
 
 
 class CRUDActionsTest(FunctionalTest):
-
     def setUp(self):
         self.browser = webdriver.Firefox()
         self.book = Book.objects.create(
-            title='Life of John Doe',
-            publication_date='2017-02-02',
-            author='John Doe',
+            title="Life of John Doe",
+            publication_date="2017-02-02",
+            author="John Doe",
             price=19,
             pages=477,
-            book_type=1
+            book_type=1,
         )
 
     def test_create_object(self):
@@ -111,174 +135,164 @@ class CRUDActionsTest(FunctionalTest):
         self.browser.get(self.live_server_url)
 
         # User clicks create book button
-        self.browser.find_element_by_class_name('create-book').click()
+        self.browser.find_element_by_class_name("create-book").click()
 
         # Create book modal opens
         modal = self.wait_for_modal("create-modal")
 
         # User fills in and submits the form with wrong date format
-        form = modal.find_element_by_tag_name('form')
-        title_field = form.find_element_by_id('id_title')
-        publication_date_field = form.find_element_by_id('id_publication_date')
-        author_field = form.find_element_by_id('id_author')
-        price_field = form.find_element_by_id('id_price')
-        pages_field = form.find_element_by_id('id_pages')
-        book_type = form.find_element_by_id('id_book_type')
+        form = modal.find_element_by_tag_name("form")
+        title_field = form.find_element_by_id("id_title")
+        publication_date_field = form.find_element_by_id("id_publication_date")
+        author_field = form.find_element_by_id("id_author")
+        price_field = form.find_element_by_id("id_price")
+        pages_field = form.find_element_by_id("id_pages")
+        book_type = form.find_element_by_id("id_book_type")
         book_type_select = Select(book_type)
 
-        title_field.send_keys('Life of Jane Doe')
-        publication_date_field.send_keys('01.01.2019')
-        author_field.send_keys('Jane Doe')
+        title_field.send_keys("Life of Jane Doe")
+        publication_date_field.send_keys("01.01.2019")
+        author_field.send_keys("Jane Doe")
         price_field.send_keys(21)
         pages_field.send_keys(464)
         book_type_select.select_by_index(1)
 
-        create_btn = modal.find_element_by_class_name('submit-btn')
+        create_btn = modal.find_element_by_class_name("submit-btn")
         create_btn.click()
 
         # User sees error in form
-        error = modal.find_element_by_class_name('help-block').text
-        self.assertEqual(error, 'Enter a valid date in YYYY-MM-DD format.')
+        error = modal.find_element_by_class_name("help-block").text
+        self.assertEqual(error, "Enter a valid date in YYYY-MM-DD format.")
 
         # User corrects the date and submits the form
-        form = modal.find_element_by_tag_name('form')
-        publication_date_field = form.find_element_by_id('id_publication_date')
+        form = modal.find_element_by_tag_name("form")
+        publication_date_field = form.find_element_by_id("id_publication_date")
         publication_date_field.clear()
-        publication_date_field.send_keys('2019-01-01')
-        create_btn = modal.find_element_by_class_name('submit-btn')
+        publication_date_field.send_keys("2019-01-01")
+        create_btn = modal.find_element_by_class_name("submit-btn")
         create_btn.click()
 
         # User sees success message after page redirection
         redirect_url = self.browser.current_url
-        self.assertRegex(redirect_url, '/')
+        self.assertRegex(redirect_url, "/")
 
         # Slice removes '\nx' since alert is dismissible and contains 'times' button
-        success_msg = self.browser.find_element_by_class_name('alert').text[:-2]
-        self.assertEqual(
-            success_msg,
-            'Success: Book was created.'
-        )
+        success_msg = self.browser.find_element_by_class_name("alert").text[:-2]
+        self.assertEqual(success_msg, "Success: Book was created.")
 
         # User sees created book in table
         table_entries = self.wait_for_table_rows()
         self.assertEqual(len(table_entries), 2)
 
         # Check content of second table entry
-        self.check_table_row(table_entries[1], 7, [
-            'Life of Jane Doe',
-            'Jane Doe',
-            'Hardcover',
-            'Jan. 1, 2019',
-            '464',
-            '21.00',
-            None
-        ])
+        self.check_table_row(
+            table_entries[1],
+            7,
+            ["Life of Jane Doe", "Jane Doe", "Hardcover", "Jan. 1, 2019", "464", "21.00", None],
+        )
 
     def test_update_object(self):
         # User visits homepage
         self.browser.get(self.live_server_url)
 
         # User clicks update book button
-        self.browser.find_element_by_class_name('update-book').click()
+        self.browser.find_element_by_class_name("update-book").click()
 
         # Update book modal opens
         modal = self.wait_for_modal("modal")
 
         # User changes price and book type
-        form = modal.find_element_by_tag_name('form')
-        title_field = form.find_element_by_id('id_title')
+        form = modal.find_element_by_tag_name("form")
+        title_field = form.find_element_by_id("id_title")
         title_field.clear()
-        book_type = form.find_element_by_id('id_book_type')
+        book_type = form.find_element_by_id("id_book_type")
         book_type_select = Select(book_type)
 
-        title_field.send_keys('Life of Jane and John Doe')
+        title_field.send_keys("Life of Jane and John Doe")
         book_type_select.select_by_index(2)
 
-        update_btn = modal.find_element_by_class_name('submit-btn')
+        update_btn = modal.find_element_by_class_name("submit-btn")
         update_btn.click()
 
         # User sees success message after page redirection
         redirect_url = self.browser.current_url
-        self.assertRegex(redirect_url, '/')
+        self.assertRegex(redirect_url, "/")
 
         # Slice removes '\nx' since alert is dismissible and contains 'times' button
-        success_msg = self.browser.find_element_by_class_name('alert').text[:-2]
-        self.assertEqual(
-            success_msg,
-            'Success: Book was updated.'
-        )
+        success_msg = self.browser.find_element_by_class_name("alert").text[:-2]
+        self.assertEqual(success_msg, "Success: Book was updated.")
 
         # User sees updated book in table
         table_entries = self.wait_for_table_rows()
         self.assertEqual(len(table_entries), 1)
 
         # Check content of first table entry
-        self.check_table_row(table_entries[0], 7, [
-            'Life of Jane and John Doe',
-            'John Doe',
-            'Paperback',
-            'Feb. 2, 2017',
-            '477',
-            '19.00',
-            None
-        ])
+        self.check_table_row(
+            table_entries[0],
+            7,
+            [
+                "Life of Jane and John Doe",
+                "John Doe",
+                "Paperback",
+                "Feb. 2, 2017",
+                "477",
+                "19.00",
+                None,
+            ],
+        )
 
     def test_read_object(self):
         # User visits homepage
         self.browser.get(self.live_server_url)
 
         # User clicks Read book button
-        self.browser.find_element_by_class_name('read-book').click()
+        self.browser.find_element_by_class_name("read-book").click()
 
         # Read book modal opens
         modal = self.wait_for_modal("modal")
 
         # User sees book content
-        modal_body = modal.find_element_by_class_name('modal-body')
-        divs = modal_body.find_elements_by_tag_name('div')
-        self.assertEqual(divs[0].text, 'Title: Life of John Doe')
-        self.assertEqual(divs[1].text, 'Author: John Doe')
-        self.assertEqual(divs[2].text, 'Price: 19.00 €')
-        self.assertEqual(divs[3].text, 'Pages: 477')
-        self.assertEqual(divs[4].text, 'Type: Hardcover')
-        self.assertEqual(divs[5].text, 'Publication date: Feb. 2, 2017')
+        modal_body = modal.find_element_by_class_name("modal-body")
+        divs = modal_body.find_elements_by_tag_name("div")
+        self.assertEqual(divs[0].text, "Title: Life of John Doe")
+        self.assertEqual(divs[1].text, "Author: John Doe")
+        self.assertEqual(divs[2].text, "Price: 19.00 €")
+        self.assertEqual(divs[3].text, "Pages: 477")
+        self.assertEqual(divs[4].text, "Type: Hardcover")
+        self.assertEqual(divs[5].text, "Publication date: Feb. 2, 2017")
 
     def test_delete_object(self):
         # User visits homepage
         self.browser.get(self.live_server_url)
 
         # User clicks Delete book button
-        self.browser.find_element_by_class_name('delete-book').click()
+        self.browser.find_element_by_class_name("delete-book").click()
 
         # Delete book modal opens
         modal = self.wait_for_modal("modal")
 
         # User sees modal content
-        modal_body = modal.find_element_by_class_name('modal-body')
-        delete_text = modal_body.find_element_by_class_name('delete-text').text
+        modal_body = modal.find_element_by_class_name("modal-body")
+        delete_text = modal_body.find_element_by_class_name("delete-text").text
         self.assertEqual(
-            delete_text,
-            'Are you sure you want to delete book with title Life of John Doe?'
+            delete_text, "Are you sure you want to delete book with title Life of John Doe?"
         )
 
         # User clicks delete button
-        delete_btn = modal.find_element_by_class_name('delete-btn')
+        delete_btn = modal.find_element_by_class_name("delete-btn")
         delete_btn.click()
 
         # User sees success message after page redirection
         redirect_url = self.browser.current_url
-        self.assertRegex(redirect_url, '/')
+        self.assertRegex(redirect_url, "/")
 
         # Slice removes '\nx' since alert is dismissible and contains 'times' button
-        success_msg = self.browser.find_element_by_class_name('alert').text[:-2]
-        self.assertEqual(
-            success_msg,
-            'Success: Book was deleted.'
-        )
+        success_msg = self.browser.find_element_by_class_name("alert").text[:-2]
+        self.assertEqual(success_msg, "Success: Book was deleted.")
 
         # User sees 'No books added yet.'
-        no_books = self.browser.find_element_by_class_name('no-books')
-        self.assertEqual(no_books.text, 'No books added yet.')
+        no_books = self.browser.find_element_by_class_name("no-books")
+        self.assertEqual(no_books.text, "No books added yet.")
 
         # There is no books in database anymore
         books = Book.objects.all()

--- a/tests/tests_functional.py
+++ b/tests/tests_functional.py
@@ -1,39 +1,7 @@
-from selenium import webdriver
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import ui, expected_conditions
 from selenium.webdriver.support.select import Select
 
 from examples.models import Book
 from .base import FunctionalTest
-
-
-class SimpleFormTest(FunctionalTest):
-    def test_signup_login(self):
-        # User visits homepage and checks the content
-        self.browser.get(self.live_server_url)
-
-        # User clicks the send comment button
-        self.browser.find_element_by_class_name('simple-btn').click()
-
-        # Create book modal opens
-        modal = self.wait_for_modal('modal')
-
-        # User add a comment
-        form = modal.find_element_by_tag_name('form')
-        comment_field = form.find_element_by_id('id_comment')
-        comment_field.clear()
-        comment_field.send_keys('What a great package!')
-
-        update_btn = modal.find_element_by_class_name('submit-btn')
-        update_btn.click()
-
-        # User sees success message after page redirection
-        redirect_url = self.browser.current_url
-        self.assertRegex(redirect_url, '/')
-
-        # Slice removes '\nx' since alert is dismissible and contains 'times' button
-        success_msg = self.browser.find_element_by_class_name('alert').text[:-2]
-        self.assertEqual(success_msg, 'Success: your comment \'What a great package!\' was taken into account!')
 
 
 class SignUpLoginTest(FunctionalTest):
@@ -45,10 +13,10 @@ class SignUpLoginTest(FunctionalTest):
         self.assertIn('django-bootstrap-modal-forms', header_text)
 
         # User clicks Sign up button
-        self.browser.find_element_by_class_name('signup-btn').click()
+        self.browser.find_element_by_id('signup-btn').click()
 
         # Sign up modal opens
-        modal = self.wait_for_modal('modal')
+        modal = self.wait_for(element_id='modal')
 
         # User fills in and submits sign up form with misspelled second password
         form = modal.find_element_by_tag_name('form')
@@ -78,14 +46,14 @@ class SignUpLoginTest(FunctionalTest):
         redirect_url = self.browser.current_url
         self.assertRegex(redirect_url, '/')
         # Slice removes '\nx' since alert is dismissible and contains 'times' button
-        success_msg = self.browser.find_element_by_class_name('alert').text[:-2]
+        success_msg = self.wait_for(class_name='alert').text[:-2]
         self.assertEqual(success_msg, 'Success: Sign up succeeded. You can now Log in.')
 
         # User clicks log in button
-        self.browser.find_element_by_class_name('login-btn').click()
+        self.browser.find_element_by_id('login-btn').click()
 
         # Log in modal opens
-        modal = self.wait_for_modal('modal')
+        modal = self.wait_for(element_id='modal')
 
         # User fills in and submits log in form with misspelled username
         form = modal.find_element_by_tag_name('form')
@@ -97,7 +65,7 @@ class SignUpLoginTest(FunctionalTest):
         login_btn.click()
 
         # User sees error in form
-        error = modal.find_element_by_class_name('invalid').text
+        error = self.wait_for(class_name='invalid').text
         self.assertEqual(
             error,
             'Please enter a correct username and password. Note that both fields may be case-sensitive.',
@@ -114,18 +82,15 @@ class SignUpLoginTest(FunctionalTest):
         login_btn.click()
 
         # User sees log out button after page redirection
+        logout_btn_txt = self.wait_for(element_id='logout-btn').text
+        self.assertEqual(logout_btn_txt, 'Log out')
         redirect_url = self.browser.current_url
         self.assertRegex(redirect_url, '/')
-        logout_btn_txt = self.browser.find_element_by_class_name('logout-btn').text
-        self.assertEqual(logout_btn_txt, 'Log out')
 
 
 class CRUDActionsTest(FunctionalTest):
     def setUp(self):
-        # capabilities = {'chromeOptions': {'useAutomationExtension': False}}
-        options = webdriver.ChromeOptions()
-        options.add_experimental_option('useAutomationExtension', False)
-        self.browser = webdriver.Chrome(options=options)
+        super().setUp()
         self.book = Book.objects.create(
             title='Life of John Doe',
             publication_date='2017-02-02',
@@ -140,13 +105,13 @@ class CRUDActionsTest(FunctionalTest):
         self.browser.get(self.live_server_url)
 
         # User clicks create book button
-        self.browser.find_element_by_class_name('create-book').click()
+        self.browser.find_element_by_id('create-book').click()
 
         # Create book modal opens
-        modal = self.wait_for_modal('create-modal')
+        modal = self.wait_for(element_id='create-modal')
 
         # User fills in and submits the form with wrong date format
-        form = modal.find_element_by_tag_name('form')
+        form = self.wait_for(tag='form')
         title_field = form.find_element_by_id('id_title')
         publication_date_field = form.find_element_by_id('id_publication_date')
         author_field = form.find_element_by_id('id_author')
@@ -165,8 +130,10 @@ class CRUDActionsTest(FunctionalTest):
         create_btn = modal.find_element_by_class_name('submit-btn')
         create_btn.click()
 
+        self.wait_for(class_name='help-block')
+
         # User sees error in form
-        error = modal.find_element_by_class_name('help-block').text
+        error = self.wait_for(class_name='help-block').text
         self.assertEqual(error, 'Enter a valid date in YYYY-MM-DD format.')
 
         # User corrects the date and submits the form
@@ -182,7 +149,7 @@ class CRUDActionsTest(FunctionalTest):
         self.assertRegex(redirect_url, '/')
 
         # Slice removes '\nx' since alert is dismissible and contains 'times' button
-        success_msg = self.browser.find_element_by_class_name('alert').text[:-2]
+        success_msg = self.wait_for(class_name='alert').text[:-2]
         self.assertEqual(success_msg, 'Success: Book was created.')
 
         # User sees created book in table
@@ -201,16 +168,13 @@ class CRUDActionsTest(FunctionalTest):
         self.browser.get(self.live_server_url)
 
         # User clicks filter book button
-        self.browser.find_element_by_class_name('filter-book').click()
+        self.wait_for(element_id='filter-book').click()
 
         # Update filter modal opens
-        modal = self.wait_for_modal('modal')
+        modal = self.wait_for(element_id='modal')
 
         # User changes price and book type
-        form = modal.find_element_by_tag_name('form')
-        book_type = ui.WebDriverWait(self.browser, 10000).until(expected_conditions.element_to_be_clickable((By.ID, 'id_type')))
-        book_type = self.wait_for_element(element_id="id_type")
-
+        book_type = self.browser.find_element_by_id("id_type")
         book_type_select = Select(book_type)
         book_type_select.select_by_index(2)
 
@@ -218,6 +182,7 @@ class CRUDActionsTest(FunctionalTest):
         filter_btn.click()
 
         # User is redirected to the index with a querystring with the filter
+        self.wait_for(element_id='filter-book')
         redirect_url = self.browser.current_url
         self.assertRegex(redirect_url, '/?type=3$')
 
@@ -226,10 +191,10 @@ class CRUDActionsTest(FunctionalTest):
         self.browser.get(self.live_server_url)
 
         # User clicks update book button
-        self.browser.find_element_by_class_name('update-book').click()
+        self.browser.find_element_by_id('update-book').click()
 
         # Update book modal opens
-        modal = self.wait_for_modal('modal')
+        modal = self.wait_for(element_id='modal')
 
         # User changes price and book type
         form = modal.find_element_by_tag_name('form')
@@ -276,10 +241,10 @@ class CRUDActionsTest(FunctionalTest):
         self.browser.get(self.live_server_url)
 
         # User clicks Read book button
-        self.browser.find_element_by_class_name('read-book').click()
+        self.browser.find_element_by_id('read-book').click()
 
         # Read book modal opens
-        modal = self.wait_for_modal('modal')
+        modal = self.wait_for(element_id='modal')
 
         # User sees book content
         modal_body = modal.find_element_by_class_name('modal-body')
@@ -296,10 +261,10 @@ class CRUDActionsTest(FunctionalTest):
         self.browser.get(self.live_server_url)
 
         # User clicks Delete book button
-        self.browser.find_element_by_class_name('delete-book').click()
+        self.browser.find_element_by_id('delete-book').click()
 
         # Delete book modal opens
-        modal = self.wait_for_modal('modal')
+        modal = self.wait_for(element_id='modal')
 
         # User sees modal content
         modal_body = modal.find_element_by_class_name('modal-body')
@@ -309,7 +274,7 @@ class CRUDActionsTest(FunctionalTest):
         )
 
         # User clicks delete button
-        delete_btn = modal.find_element_by_class_name('delete-btn')
+        delete_btn = modal.find_element_by_id('delete-btn')
         delete_btn.click()
 
         # User sees success message after page redirection

--- a/tests/tests_functional.py
+++ b/tests/tests_functional.py
@@ -11,120 +11,120 @@ class SimpleFormTest(FunctionalTest):
         self.browser.get(self.live_server_url)
 
         # User clicks the send comment button
-        self.browser.find_element_by_class_name("simple-btn").click()
+        self.browser.find_element_by_class_name('simple-btn').click()
 
         # Create book modal opens
-        modal = self.wait_for_modal("modal")
+        modal = self.wait_for_modal('modal')
 
         # User add a comment
-        form = modal.find_element_by_tag_name("form")
-        comment_field = form.find_element_by_id("id_comment")
+        form = modal.find_element_by_tag_name('form')
+        comment_field = form.find_element_by_id('id_comment')
         comment_field.clear()
-        comment_field.send_keys("What a great package!")
+        comment_field.send_keys('What a great package!')
 
-        update_btn = modal.find_element_by_class_name("submit-btn")
+        update_btn = modal.find_element_by_class_name('submit-btn')
         update_btn.click()
 
         # User sees success message after page redirection
         redirect_url = self.browser.current_url
-        self.assertRegex(redirect_url, "/")
+        self.assertRegex(redirect_url, '/')
 
         # Slice removes '\nx' since alert is dismissible and contains 'times' button
-        success_msg = self.browser.find_element_by_class_name("alert").text[:-2]
-        self.assertEqual(success_msg, "Success: your comment 'What a great package!' was taken into account!")
+        success_msg = self.browser.find_element_by_class_name('alert').text[:-2]
+        self.assertEqual(success_msg, 'Success: your comment \'What a great package!\' was taken into account!')
 
 
 class SignUpLoginTest(FunctionalTest):
     def test_signup_login(self):
         # User visits homepage and checks the content
         self.browser.get(self.live_server_url)
-        self.assertIn("django-bootstrap-modal-forms", self.browser.title)
-        header_text = self.browser.find_element_by_tag_name("h1").text
-        self.assertIn("django-bootstrap-modal-forms", header_text)
+        self.assertIn('django-bootstrap-modal-forms', self.browser.title)
+        header_text = self.browser.find_element_by_tag_name('h1').text
+        self.assertIn('django-bootstrap-modal-forms', header_text)
 
         # User clicks Sign up button
-        self.browser.find_element_by_class_name("signup-btn").click()
+        self.browser.find_element_by_class_name('signup-btn').click()
 
         # Sign up modal opens
-        modal = self.wait_for_modal("modal")
+        modal = self.wait_for_modal('modal')
 
         # User fills in and submits sign up form with misspelled second password
-        form = modal.find_element_by_tag_name("form")
-        username_field = form.find_element_by_id("id_username")
-        password1_field = form.find_element_by_id("id_password1")
-        password2_field = form.find_element_by_id("id_password2")
-        username_field.send_keys("user")
-        password1_field.send_keys("pass12345")
-        password2_field.send_keys("wrong12345")
-        signup_btn = modal.find_element_by_class_name("submit-btn")
+        form = modal.find_element_by_tag_name('form')
+        username_field = form.find_element_by_id('id_username')
+        password1_field = form.find_element_by_id('id_password1')
+        password2_field = form.find_element_by_id('id_password2')
+        username_field.send_keys('user')
+        password1_field.send_keys('pass12345')
+        password2_field.send_keys('wrong12345')
+        signup_btn = modal.find_element_by_class_name('submit-btn')
         signup_btn.click()
 
         # User sees error in form
-        error = modal.find_element_by_class_name("help-block").text
-        self.assertEqual(error, "The two password fields didn't match.")
+        error = modal.find_element_by_class_name('help-block').text
+        self.assertEqual(error, 'The two password fields didn\'t match.')
 
         # User fills in and submits sign up form correctly
-        form = modal.find_element_by_tag_name("form")
-        password1_field = form.find_element_by_id("id_password1")
-        password2_field = form.find_element_by_id("id_password2")
-        password1_field.send_keys("pass12345")
-        password2_field.send_keys("pass12345")
-        signup_btn = modal.find_element_by_class_name("submit-btn")
+        form = modal.find_element_by_tag_name('form')
+        password1_field = form.find_element_by_id('id_password1')
+        password2_field = form.find_element_by_id('id_password2')
+        password1_field.send_keys('pass12345')
+        password2_field.send_keys('pass12345')
+        signup_btn = modal.find_element_by_class_name('submit-btn')
         signup_btn.click()
 
         # User sees success message after page redirection
         redirect_url = self.browser.current_url
-        self.assertRegex(redirect_url, "/")
+        self.assertRegex(redirect_url, '/')
         # Slice removes '\nx' since alert is dismissible and contains 'times' button
-        success_msg = self.browser.find_element_by_class_name("alert").text[:-2]
-        self.assertEqual(success_msg, "Success: Sign up succeeded. You can now Log in.")
+        success_msg = self.browser.find_element_by_class_name('alert').text[:-2]
+        self.assertEqual(success_msg, 'Success: Sign up succeeded. You can now Log in.')
 
         # User clicks log in button
-        self.browser.find_element_by_class_name("login-btn").click()
+        self.browser.find_element_by_class_name('login-btn').click()
 
         # Log in modal opens
-        modal = self.wait_for_modal("modal")
+        modal = self.wait_for_modal('modal')
 
         # User fills in and submits log in form with misspelled username
-        form = modal.find_element_by_tag_name("form")
-        username_field = form.find_element_by_id("id_username")
-        password_field = form.find_element_by_id("id_password")
-        username_field.send_keys("wrong")
-        password_field.send_keys("pass12345")
-        login_btn = modal.find_element_by_class_name("submit-btn")
+        form = modal.find_element_by_tag_name('form')
+        username_field = form.find_element_by_id('id_username')
+        password_field = form.find_element_by_id('id_password')
+        username_field.send_keys('wrong')
+        password_field.send_keys('pass12345')
+        login_btn = modal.find_element_by_class_name('submit-btn')
         login_btn.click()
 
         # User sees error in form
-        error = modal.find_element_by_class_name("invalid").text
+        error = modal.find_element_by_class_name('invalid').text
         self.assertEqual(
             error,
-            "Please enter a correct username and password. Note that both fields may be case-sensitive.",
+            'Please enter a correct username and password. Note that both fields may be case-sensitive.',
         )
 
         # User fills in and submits log in form correctly
-        form = modal.find_element_by_tag_name("form")
-        username_field = form.find_element_by_id("id_username")
+        form = modal.find_element_by_tag_name('form')
+        username_field = form.find_element_by_id('id_username')
         username_field.clear()
-        password_field = form.find_element_by_id("id_password")
-        username_field.send_keys("user")
-        password_field.send_keys("pass12345")
-        login_btn = modal.find_element_by_class_name("submit-btn")
+        password_field = form.find_element_by_id('id_password')
+        username_field.send_keys('user')
+        password_field.send_keys('pass12345')
+        login_btn = modal.find_element_by_class_name('submit-btn')
         login_btn.click()
 
         # User sees log out button after page redirection
         redirect_url = self.browser.current_url
-        self.assertRegex(redirect_url, "/")
-        logout_btn_txt = self.browser.find_element_by_class_name("logout-btn").text
-        self.assertEqual(logout_btn_txt, "Log out")
+        self.assertRegex(redirect_url, '/')
+        logout_btn_txt = self.browser.find_element_by_class_name('logout-btn').text
+        self.assertEqual(logout_btn_txt, 'Log out')
 
 
 class CRUDActionsTest(FunctionalTest):
     def setUp(self):
         self.browser = webdriver.Firefox()
         self.book = Book.objects.create(
-            title="Life of John Doe",
-            publication_date="2017-02-02",
-            author="John Doe",
+            title='Life of John Doe',
+            publication_date='2017-02-02',
+            author='John Doe',
             price=19,
             pages=477,
             book_type=1,
@@ -135,50 +135,50 @@ class CRUDActionsTest(FunctionalTest):
         self.browser.get(self.live_server_url)
 
         # User clicks create book button
-        self.browser.find_element_by_class_name("create-book").click()
+        self.browser.find_element_by_class_name('create-book').click()
 
         # Create book modal opens
-        modal = self.wait_for_modal("create-modal")
+        modal = self.wait_for_modal('create-modal')
 
         # User fills in and submits the form with wrong date format
-        form = modal.find_element_by_tag_name("form")
-        title_field = form.find_element_by_id("id_title")
-        publication_date_field = form.find_element_by_id("id_publication_date")
-        author_field = form.find_element_by_id("id_author")
-        price_field = form.find_element_by_id("id_price")
-        pages_field = form.find_element_by_id("id_pages")
-        book_type = form.find_element_by_id("id_book_type")
+        form = modal.find_element_by_tag_name('form')
+        title_field = form.find_element_by_id('id_title')
+        publication_date_field = form.find_element_by_id('id_publication_date')
+        author_field = form.find_element_by_id('id_author')
+        price_field = form.find_element_by_id('id_price')
+        pages_field = form.find_element_by_id('id_pages')
+        book_type = form.find_element_by_id('id_book_type')
         book_type_select = Select(book_type)
 
-        title_field.send_keys("Life of Jane Doe")
-        publication_date_field.send_keys("01.01.2019")
-        author_field.send_keys("Jane Doe")
+        title_field.send_keys('Life of Jane Doe')
+        publication_date_field.send_keys('01.01.2019')
+        author_field.send_keys('Jane Doe')
         price_field.send_keys(21)
         pages_field.send_keys(464)
         book_type_select.select_by_index(1)
 
-        create_btn = modal.find_element_by_class_name("submit-btn")
+        create_btn = modal.find_element_by_class_name('submit-btn')
         create_btn.click()
 
         # User sees error in form
-        error = modal.find_element_by_class_name("help-block").text
-        self.assertEqual(error, "Enter a valid date in YYYY-MM-DD format.")
+        error = modal.find_element_by_class_name('help-block').text
+        self.assertEqual(error, 'Enter a valid date in YYYY-MM-DD format.')
 
         # User corrects the date and submits the form
-        form = modal.find_element_by_tag_name("form")
-        publication_date_field = form.find_element_by_id("id_publication_date")
+        form = modal.find_element_by_tag_name('form')
+        publication_date_field = form.find_element_by_id('id_publication_date')
         publication_date_field.clear()
-        publication_date_field.send_keys("2019-01-01")
-        create_btn = modal.find_element_by_class_name("submit-btn")
+        publication_date_field.send_keys('2019-01-01')
+        create_btn = modal.find_element_by_class_name('submit-btn')
         create_btn.click()
 
         # User sees success message after page redirection
         redirect_url = self.browser.current_url
-        self.assertRegex(redirect_url, "/")
+        self.assertRegex(redirect_url, '/')
 
         # Slice removes '\nx' since alert is dismissible and contains 'times' button
-        success_msg = self.browser.find_element_by_class_name("alert").text[:-2]
-        self.assertEqual(success_msg, "Success: Book was created.")
+        success_msg = self.browser.find_element_by_class_name('alert').text[:-2]
+        self.assertEqual(success_msg, 'Success: Book was created.')
 
         # User sees created book in table
         table_entries = self.wait_for_table_rows()
@@ -188,7 +188,7 @@ class CRUDActionsTest(FunctionalTest):
         self.check_table_row(
             table_entries[1],
             7,
-            ["Life of Jane Doe", "Jane Doe", "Hardcover", "Jan. 1, 2019", "464", "21.00", None],
+            ['Life of Jane Doe', 'Jane Doe', 'Hardcover', 'Jan. 1, 2019', '464', '21.00', None],
         )
 
     def test_update_object(self):
@@ -196,31 +196,31 @@ class CRUDActionsTest(FunctionalTest):
         self.browser.get(self.live_server_url)
 
         # User clicks update book button
-        self.browser.find_element_by_class_name("update-book").click()
+        self.browser.find_element_by_class_name('update-book').click()
 
         # Update book modal opens
-        modal = self.wait_for_modal("modal")
+        modal = self.wait_for_modal('modal')
 
         # User changes price and book type
-        form = modal.find_element_by_tag_name("form")
-        title_field = form.find_element_by_id("id_title")
+        form = modal.find_element_by_tag_name('form')
+        title_field = form.find_element_by_id('id_title')
         title_field.clear()
-        book_type = form.find_element_by_id("id_book_type")
+        book_type = form.find_element_by_id('id_book_type')
         book_type_select = Select(book_type)
 
-        title_field.send_keys("Life of Jane and John Doe")
+        title_field.send_keys('Life of Jane and John Doe')
         book_type_select.select_by_index(2)
 
-        update_btn = modal.find_element_by_class_name("submit-btn")
+        update_btn = modal.find_element_by_class_name('submit-btn')
         update_btn.click()
 
         # User sees success message after page redirection
         redirect_url = self.browser.current_url
-        self.assertRegex(redirect_url, "/")
+        self.assertRegex(redirect_url, '/')
 
         # Slice removes '\nx' since alert is dismissible and contains 'times' button
-        success_msg = self.browser.find_element_by_class_name("alert").text[:-2]
-        self.assertEqual(success_msg, "Success: Book was updated.")
+        success_msg = self.browser.find_element_by_class_name('alert').text[:-2]
+        self.assertEqual(success_msg, 'Success: Book was updated.')
 
         # User sees updated book in table
         table_entries = self.wait_for_table_rows()
@@ -231,12 +231,12 @@ class CRUDActionsTest(FunctionalTest):
             table_entries[0],
             7,
             [
-                "Life of Jane and John Doe",
-                "John Doe",
-                "Paperback",
-                "Feb. 2, 2017",
-                "477",
-                "19.00",
+                'Life of Jane and John Doe',
+                'John Doe',
+                'Paperback',
+                'Feb. 2, 2017',
+                '477',
+                '19.00',
                 None,
             ],
         )
@@ -246,53 +246,53 @@ class CRUDActionsTest(FunctionalTest):
         self.browser.get(self.live_server_url)
 
         # User clicks Read book button
-        self.browser.find_element_by_class_name("read-book").click()
+        self.browser.find_element_by_class_name('read-book').click()
 
         # Read book modal opens
-        modal = self.wait_for_modal("modal")
+        modal = self.wait_for_modal('modal')
 
         # User sees book content
-        modal_body = modal.find_element_by_class_name("modal-body")
-        divs = modal_body.find_elements_by_tag_name("div")
-        self.assertEqual(divs[0].text, "Title: Life of John Doe")
-        self.assertEqual(divs[1].text, "Author: John Doe")
-        self.assertEqual(divs[2].text, "Price: 19.00 €")
-        self.assertEqual(divs[3].text, "Pages: 477")
-        self.assertEqual(divs[4].text, "Type: Hardcover")
-        self.assertEqual(divs[5].text, "Publication date: Feb. 2, 2017")
+        modal_body = modal.find_element_by_class_name('modal-body')
+        divs = modal_body.find_elements_by_tag_name('div')
+        self.assertEqual(divs[0].text, 'Title: Life of John Doe')
+        self.assertEqual(divs[1].text, 'Author: John Doe')
+        self.assertEqual(divs[2].text, 'Price: 19.00 €')
+        self.assertEqual(divs[3].text, 'Pages: 477')
+        self.assertEqual(divs[4].text, 'Type: Hardcover')
+        self.assertEqual(divs[5].text, 'Publication date: Feb. 2, 2017')
 
     def test_delete_object(self):
         # User visits homepage
         self.browser.get(self.live_server_url)
 
         # User clicks Delete book button
-        self.browser.find_element_by_class_name("delete-book").click()
+        self.browser.find_element_by_class_name('delete-book').click()
 
         # Delete book modal opens
-        modal = self.wait_for_modal("modal")
+        modal = self.wait_for_modal('modal')
 
         # User sees modal content
-        modal_body = modal.find_element_by_class_name("modal-body")
-        delete_text = modal_body.find_element_by_class_name("delete-text").text
+        modal_body = modal.find_element_by_class_name('modal-body')
+        delete_text = modal_body.find_element_by_class_name('delete-text').text
         self.assertEqual(
-            delete_text, "Are you sure you want to delete book with title Life of John Doe?"
+            delete_text, 'Are you sure you want to delete book with title Life of John Doe?'
         )
 
         # User clicks delete button
-        delete_btn = modal.find_element_by_class_name("delete-btn")
+        delete_btn = modal.find_element_by_class_name('delete-btn')
         delete_btn.click()
 
         # User sees success message after page redirection
         redirect_url = self.browser.current_url
-        self.assertRegex(redirect_url, "/")
+        self.assertRegex(redirect_url, '/')
 
         # Slice removes '\nx' since alert is dismissible and contains 'times' button
-        success_msg = self.browser.find_element_by_class_name("alert").text[:-2]
-        self.assertEqual(success_msg, "Success: Book was deleted.")
+        success_msg = self.browser.find_element_by_class_name('alert').text[:-2]
+        self.assertEqual(success_msg, 'Success: Book was deleted.')
 
         # User sees 'No books added yet.'
-        no_books = self.browser.find_element_by_class_name("no-books")
-        self.assertEqual(no_books.text, "No books added yet.")
+        no_books = self.browser.find_element_by_class_name('no-books')
+        self.assertEqual(no_books.text, 'No books added yet.')
 
         # There is no books in database anymore
         books = Book.objects.all()


### PR DESCRIPTION
hello @trco , could you look at this WIP ?

Some question I have is about the naming of the views. I have added the simplest View as
```
class BSModalView(PassRequestMixin, generic.FormView):
    pass
```
which names look OK to me.

The simples Form is then
```
class BSForm(PopRequestMixin, forms.Form):
    pass
```
but this breaks the prepending of all objects by BSModal.
However the `BSModalForm` is already used for what should have been probably named `BSModalModelForm`.
Is it worth to break the backward compatibility and do this renaming ? or do you prefer to keep the slightly inconsistent (and a bit puzzling to me when I was trying to make sense of the package) ?
Personnally, I think it would be better to rename for the LT.
But this may require a bump of the major version number of the lib.