### PR TITLE
Async delete

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -212,7 +212,7 @@ Add script to the template from #5 and bind the ``modalForm`` to the trigger ele
     });
     </script>
 
-Async create/update with or without modal closing on submit
+Async create/update/delete with or without modal closing on submit
 ===========================================================
 
 Set ``asyncUpdate`` and ``asyncSettings`` settings to create or update objects without page redirection to ``successUrl`` and define whether a modal should close or stay opened after form submission. See comments in example below and paragraph **modalForm options** for explanation of ``asyncSettings``.
@@ -233,6 +233,10 @@ Set ``asyncUpdate`` and ``asyncSettings`` settings to create or update objects w
             <!-- Update book buttons -->
             <button type="button" class="update-book btn btn-sm btn-primary" data-form-url="{% url 'update_book' book.pk %}">
               <span class="fa fa-pencil"></span>
+            </button>
+            <!-- Delete book buttons -->
+            <button type="button" class="delete-book-async btn btn-sm btn-danger" data-form-url="{% url 'delete_book' book.pk %}">
+              <span class="fa fa-trash"></span>
             </button>
             ...
           </td>
@@ -278,6 +282,26 @@ Set ``asyncUpdate`` and ``asyncSettings`` settings to create or update objects w
               });
             }
             updateBookModalForm();
+
+            //checking for form validity on delete means submitting the delete form twice, causing an error
+            function deleteBookModalForm() {
+              $(".delete-book").each(function () {
+                $(this).modalForm({
+                  formURL: $(this).data("form-url"),
+                  asyncUpdate: true,
+                  checkValidBeforeSubmit: false,
+                  asyncSettings: {
+                    closeOnSubmit: false,
+                    successMessage: asyncSuccessMessage,
+                    dataUrl: "books/",
+                    dataElementId: "#books-table",
+                    dataKey: "table",
+                    addModalFormFunction: deleteBookModalForm
+                  }
+                });
+              });
+            }
+          deleteBookModalForm();
         
             ...
         });
@@ -337,6 +361,9 @@ errorClass
 
 submitBtn
   Sets the custom class for the button triggering form submission in modal. ``Default: ".submit-btn"``
+
+checkValidBeforeSubmit
+  Sets whether to check form validity before submitting (set to false for async delete). ``Default: true``
 
 asyncUpdate
   Sets asynchronous content update after form submission. ``Default: false``

--- a/bootstrap_modal_forms/static/js/jquery.bootstrap.modal.forms.js
+++ b/bootstrap_modal_forms/static/js/jquery.bootstrap.modal.forms.js
@@ -19,7 +19,12 @@ https://github.com/trco/django-bootstrap-modal-forms
     var addEventHandlers = function (settings) {
         // submitBtn click handler
         $(settings.submitBtn).on("click", function (event) {
-            isFormValid(settings, submitForm);
+            if (settings.checkValidBeforeSubmit) {
+                isFormValid(settings, submitForm);
+            }
+            else {
+                submitForm(settings);
+            }
         });
         // Modal close handler
         $(settings.modalID).on("hidden.bs.modal", function (event) {
@@ -144,6 +149,7 @@ https://github.com/trco/django-bootstrap-modal-forms
             formURL: null,
             errorClass: ".invalid",
             submitBtn: ".submit-btn",
+            checkValidBeforeSubmit: true,
             asyncUpdate: false,
             asyncSettings: {
                 closeOnSubmit: false,

--- a/examples/templates/_books_table.html
+++ b/examples/templates/_books_table.html
@@ -8,7 +8,7 @@
     <th class="text-center" scope="col">Publication date</th>
     <th class="text-center" scope="col">Pages</th>
     <th class="text-center" scope="col">Price (€)</th>
-    <th class="text-center" scope="col">Read / Update / Delete</th>
+    <th class="text-center" scope="col">Read / Update / Delete / Async Delete</th>
   </tr>
   </thead>
   <tbody>
@@ -32,6 +32,10 @@
         </button>
         <!-- Delete book buttons -->
         <button type="button" class="bs-modal delete-book btn btn-sm btn-danger" data-form-url="{% url 'delete_book' book.pk %}">
+          <span class="fa fa-trash"></span>
+        </button>
+        <!-- Async delete book button -->
+        <button type="button" class="delete-book-async btn btn-sm btn-danger" data-form-url="{% url 'delete_book_async' book.pk %}">
           <span class="fa fa-trash"></span>
         </button>
       </td>

--- a/examples/templates/examples/delete_book_async.html
+++ b/examples/templates/examples/delete_book_async.html
@@ -1,0 +1,22 @@
+{% load widget_tweaks %}
+
+<form method="post" action="">
+  {% csrf_token %}
+
+  <div class="modal-header">
+    <h3 class="modal-title">Delete Book</h3>
+    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+
+  <div class="modal-body">
+    <p class="delete-text">Are you sure you want to delete book with title
+      <strong>{{ book.title }}</strong>?</p>
+  </div>
+
+  <div class="modal-footer">
+    <button type="button" class="submit-btn btn btn-primary">Delete</button>
+  </div>
+
+</form>

--- a/examples/templates/index.html
+++ b/examples/templates/index.html
@@ -114,6 +114,25 @@
           }
           updateBookModalForm();
 
+          function deleteBookModalForm() {
+            $(".delete-book-async").each(function () {
+              $(this).modalForm({
+                formURL: $(this).data("form-url"),
+                asyncUpdate: true,
+                checkValidBeforeSubmit: false,
+                asyncSettings: {
+                  closeOnSubmit: true,
+                  successMessage: asyncSuccessMessage,
+                  dataUrl: "books/",
+                  dataElementId: "#books-table",
+                  dataKey: "table",
+                  addModalFormFunction: deleteBookModalForm
+                }
+              });
+            });
+          }
+          deleteBookModalForm();
+
           // Read and Delete book buttons open modal with id="modal"
           // The formURL is retrieved from the data of the element
           $(".bs-modal").each(function () {

--- a/examples/urls.py
+++ b/examples/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path('update/<int:pk>', views.BookUpdateView.as_view(), name='update_book'),
     path('read/<int:pk>', views.BookReadView.as_view(), name='read_book'),
     path('delete/<int:pk>', views.BookDeleteView.as_view(), name='delete_book'),
+    path('delete/async/<int:pk>', views.BookDeleteAsyncView.as_view(), name='delete_book_async'),
     path('books/', views.books, name='books'),
     path('signup/', views.SignUpView.as_view(), name='signup'),
     path('login/', views.CustomLoginView.as_view(), name='login'),

--- a/examples/views.py
+++ b/examples/views.py
@@ -78,6 +78,13 @@ class BookDeleteView(BSModalDeleteView):
     success_url = reverse_lazy('index')
 
 
+class BookDeleteAsyncView(BSModalDeleteView):
+    model = Book
+    template_name = 'examples/delete_book_async.html'
+    success_message = 'Success: Book was deleted.'
+    success_url = reverse_lazy('index')
+
+
 class SignUpView(BSModalCreateView):
     form_class = CustomUserCreationForm
     template_name = 'examples/signup.html'


### PR DESCRIPTION
Currently, async deletes don't work because the js submits them twice (once to validate the form, once to actually perform the action). If we assume deletes don't generally require form validation, then the problem is solved by adding a setting that skips the form validation step and submits it directly.

Also added async delete code alongside the standard delete code to show how to use the new setting.