### PR TITLE
Add html5 form validation before sending

### DIFF
--- a/bootstrap_modal_forms/static/js/jquery.bootstrap.modal.forms.js
+++ b/bootstrap_modal_forms/static/js/jquery.bootstrap.modal.forms.js
@@ -30,6 +30,13 @@ https://github.com/trco/django-bootstrap-modal-forms
 
     // Check if form.is_valid() & either show errors or submit it via callback
     var isFormValid = function (settings, callback) {
+        if (!$(settings.modalForm)[0].checkValidity()) {
+            var elemstohide = $("input:hidden, textarea:hidden, select:hidden").filter("*:enabled")
+            elemstohide.attr("disabled", true);
+            $(settings.modalForm)[0].reportValidity()
+            elemstohide.attr("disabled", false);
+            return false;
+        }
         $.ajax({
             type: $(settings.modalForm).attr("method"),
             url: $(settings.modalForm).attr("action"),


### PR DESCRIPTION
This Runs the validation of html5 forms before sending the request to the server. 

It hides hidden elements to avoid errors in javascript if the form has temporarly hidden elements (for example tabs).