### PR TITLE
Fix submitting the form using Enter key.

### DIFF
--- a/bootstrap_modal_forms/static/js/jquery.bootstrap.modal.forms.js
+++ b/bootstrap_modal_forms/static/js/jquery.bootstrap.modal.forms.js
@@ -22,9 +22,9 @@ https://github.com/trco/django-bootstrap-modal-forms
             isFormValid(settings, submitForm);
         });
         // Support submition on form fields
-        $(settings.modalForm).on("submit", function (e) {
-            if (e.originalEvent !== undefined) {
-                e.preventDefault();
+        $(settings.modalForm).on("submit", function (event) {
+            if (event.originalEvent !== undefined) {
+                event.preventDefault();
                 isFormValid(settings, submitForm);
                 return false;
             }

--- a/bootstrap_modal_forms/static/js/jquery.bootstrap.modal.forms.js
+++ b/bootstrap_modal_forms/static/js/jquery.bootstrap.modal.forms.js
@@ -21,6 +21,14 @@ https://github.com/trco/django-bootstrap-modal-forms
         $(settings.submitBtn).on("click", function (event) {
             isFormValid(settings, submitForm);
         });
+        // Support submition on form fields
+        $(settings.modalForm).on("submit", function (e) {
+            if (e.originalEvent !== undefined) {
+                e.preventDefault();
+                isFormValid(settings, submitForm);
+                return false;
+            }
+        });
         // Modal close handler
         $(settings.modalID).on("hidden.bs.modal", function (event) {
             $(settings.modalForm).remove();


### PR DESCRIPTION
Submitting the form using enter key (triggering submit event via input field) bypassed the isFormValid logic and redirected to success_url if form_valid, or to raw form with errors if form_invalid. This fixes that.