### PR TITLE
DeleteMessageMixin fixes

### DIFF
--- a/bootstrap_modal_forms/mixins.py
+++ b/bootstrap_modal_forms/mixins.py
@@ -48,13 +48,18 @@ class CreateUpdateAjaxMixin(object):
 
 class DeleteMessageMixin(object):
     """
-    Mixin which adds message to BSModalDeleteView.
+    Mixin which adds message to BSModalDeleteView and only calls the delete method if request
+    is not ajax request.
     """
-
-    def post(self, request, *args, **kwargs):
-        messages.success(request, self.success_message)
-        return super(DeleteMessageMixin, self).delete(request, *args, **kwargs)
-
+   
+    def delete(self, request, *args, **kwargs):
+        if not self.request.is_ajax():
+            messages.success(request, self.success_message)
+            return super(DeleteMessageMixin, self).delete(request, *args, **kwargs)
+        else:
+            self.object = self.get_object()
+            success_url = self.get_success_url()
+            return HttpResponseDirect(success_url)
 
 class LoginAjaxMixin(object):
     """

--- a/bootstrap_modal_forms/mixins.py
+++ b/bootstrap_modal_forms/mixins.py
@@ -58,8 +58,7 @@ class DeleteMessageMixin(object):
             return super(DeleteMessageMixin, self).delete(request, *args, **kwargs)
         else:
             self.object = self.get_object()
-            success_url = self.get_success_url()
-            return HttpResponseDirect(success_url)
+            return HttpResponseRedirect(self.get_success_url())
 
 class LoginAjaxMixin(object):
     """


### PR DESCRIPTION
Changed post override to delete override.  Overriding post and calling the super delete method was causing the deletion to happen no matter how one would override the Delete method.
Added logic to only actually delete if the request is not an ajax request.  This prevents the parent deletion being called twice and throwing a 404 error on get_object when it is called on the second POST.