### PR TITLE
Fix redirect of FormValidationMixin to be compliant to standard django:

### DIFF
--- a/bootstrap_modal_forms/mixins.py
+++ b/bootstrap_modal_forms/mixins.py
@@ -89,7 +89,7 @@ class FormValidationMixin:
         
         form.save()
         messages.success(self.request, self.success_message)
-        return HttpResponseRedirect(self.success_url)   
+        return HttpResponseRedirect(self.get_success_url())
 
 
 def is_ajax(meta):


### PR DESCRIPTION
Return class property success_url if exists, if not return value from classes get_success_url method. If that doesn't exist return value from models get_absolute_url method.