### PR TITLE
Make success messages more dynamic and compliant with standard django

### DIFF
--- a/bootstrap_modal_forms/mixins.py
+++ b/bootstrap_modal_forms/mixins.py
@@ -77,7 +77,11 @@ class FormValidationMixin:
     """
     Generic View Mixin which saves object and redirects to success_url if request is not ajax request. Otherwise response 204 No content is returned.
     """
-        
+
+    def get_success_message(self):
+        if hasattr(self, 'success_message'):
+            return self.success_message
+
     def form_valid(self, form):
         isAjaxRequest = is_ajax(self.request.META)
         asyncUpdate = self.request.POST.get('asyncUpdate') == 'True'
@@ -86,9 +90,9 @@ class FormValidationMixin:
             if asyncUpdate:
                 form.save()
             return HttpResponse(status=204)
-        
+
         form.save()
-        messages.success(self.request, self.success_message)
+        messages.success(self.request, self.get_success_message())
         return HttpResponseRedirect(self.get_success_url())
 
 


### PR DESCRIPTION
Change the success message so that it can be used with either a static message (class property) or a dynamic success message from get_success_message method (so we're able to use model instance attributes in the message) or even without a message.

This doesn't seem to be of high priority, maybe we can just merge it and publish with a future release.