### PR TITLE
Fix form validation success url

### DIFF
--- a/bootstrap_modal_forms/mixins.py
+++ b/bootstrap_modal_forms/mixins.py
@@ -77,7 +77,12 @@ class FormValidationMixin:
     """
     Generic View Mixin which saves object and redirects to success_url if request is not ajax request. Otherwise response 204 No content is returned.
     """
-        
+
+    def get_success_url(self):
+        if self.success_url:
+            return self.success_url
+        return super().get_success_url()
+
     def form_valid(self, form):
         isAjaxRequest = is_ajax(self.request.META)
         asyncUpdate = self.request.POST.get('asyncUpdate') == 'True'
@@ -86,7 +91,7 @@ class FormValidationMixin:
             if asyncUpdate:
                 form.save()
             return HttpResponse(status=204)
-        
+
         form.save()
         messages.success(self.request, self.success_message)
         return HttpResponseRedirect(self.get_success_url())

--- a/bootstrap_modal_forms/mixins.py
+++ b/bootstrap_modal_forms/mixins.py
@@ -89,7 +89,7 @@ class FormValidationMixin:
         
         form.save()
         messages.success(self.request, self.success_message)
-        return HttpResponseRedirect(self.success_url)   
+        return HttpResponseRedirect(self.get_success_url())
 
 
 def is_ajax(meta):


### PR DESCRIPTION
This fixes a constellation where a view class has no get_success_url method and has the success_message class attribute set. 