### PR TITLE
#236: added self.object to form.save()

### DIFF
--- a/bootstrap_modal_forms/mixins.py
+++ b/bootstrap_modal_forms/mixins.py
@@ -93,10 +93,10 @@ class FormValidationMixin:
 
         if isAjaxRequest:
             if asyncUpdate:
-                form.save()
+                self.object = form.save()
             return HttpResponse(status=204)
 
-        form.save()
+        self.object = form.save()
         messages.success(self.request, self.get_success_message())
         return HttpResponseRedirect(self.get_success_url())
 


### PR DESCRIPTION
Closes #236 

added self.object to to the form.save() so we can control self.object in bootstrap_modal_forms/mixins.py